### PR TITLE
Minor performance improvements and test coverage

### DIFF
--- a/src/main/java/edu/kit/crate/externalproviders/organizationprovider/RorProvider.java
+++ b/src/main/java/edu/kit/crate/externalproviders/organizationprovider/RorProvider.java
@@ -22,7 +22,7 @@ public class RorProvider {
    */
   public static OrganizationEntity getOrganization(String url) {
     CloseableHttpClient httpClient = HttpClients.createDefault();
-    if (!url.matches("https://ror.org/.*")) {
+    if (!url.startsWith("https://ror.org/")) {
       throw new IllegalArgumentException("Should provide ror url");
     }
     String newUrl = "https://api.ror.org/organizations/" + url.replaceAll("https://ror.org/", "");

--- a/src/main/java/edu/kit/crate/externalproviders/personprovider/OrcidProvider.java
+++ b/src/main/java/edu/kit/crate/externalproviders/personprovider/OrcidProvider.java
@@ -30,7 +30,7 @@ public class OrcidProvider {
   public static PersonEntity getPerson(String url) {
     CloseableHttpClient httpClient = HttpClients.createDefault();
     if (!url.startsWith("https://orcid.org")) {
-      throw new IllegalArgumentException("Should provide orcid link");
+      throw new IllegalArgumentException("Should provide orcid url");
     }
     HttpGet request = new HttpGet(url);
     request.addHeader(HttpHeaders.ACCEPT, "application/ld+json");

--- a/src/main/java/edu/kit/crate/externalproviders/personprovider/OrcidProvider.java
+++ b/src/main/java/edu/kit/crate/externalproviders/personprovider/OrcidProvider.java
@@ -29,7 +29,7 @@ public class OrcidProvider {
    */
   public static PersonEntity getPerson(String url) {
     CloseableHttpClient httpClient = HttpClients.createDefault();
-    if (!url.matches("https://orcid.org.*")) {
+    if (!url.startsWith("https://orcid.org")) {
       throw new IllegalArgumentException("Should provide orcid link");
     }
     HttpGet request = new HttpGet(url);

--- a/src/main/java/edu/kit/crate/reader/RoCrateReader.java
+++ b/src/main/java/edu/kit/crate/reader/RoCrateReader.java
@@ -116,7 +116,7 @@ public class RoCrateReader {
       JsonNode type = node.get("conformsTo");
       if (type != null) {
         String uri = type.get("@id").asText();
-        if (uri.matches("https://w3id.org/ro/crate/.*")) {
+        if (uri.startsWith("https://w3id.org/ro/crate/")) {
           this.crate.setJsonDescriptor(
               new ContextualEntity.ContextualEntityBuilder().setAll(node.deepCopy()).build());
           graphCopy.remove(i);

--- a/src/test/java/edu/kit/crate/externalproviders/OrcidProviderTest.java
+++ b/src/test/java/edu/kit/crate/externalproviders/OrcidProviderTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @author Nikola Tzotchev on 10.2.2022 г.
  * @version 1
  */
-public class OrcidTest {
+public class OrcidProviderTest {
 
   @Test
   void testAddingPersonEntity() throws IOException {

--- a/src/test/java/edu/kit/crate/externalproviders/OrcidTest.java
+++ b/src/test/java/edu/kit/crate/externalproviders/OrcidTest.java
@@ -6,15 +6,32 @@ import edu.kit.crate.HelpFunctions;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 /**
  * @author Nikola Tzotchev on 10.2.2022 г.
  * @version 1
  */
-public class ORCIDTest {
+public class OrcidTest {
 
   @Test
   void testAddingPersonEntity() throws IOException {
     PersonEntity person = OrcidProvider.getPerson("https://orcid.org/0000-0001-9842-9718");
     HelpFunctions.compareEntityWithFile(person, "/json/entities/contextual/orcidperson.json");
   }
+
+  @Test
+  void testInvalidOrcidUrl() {
+    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+      PersonEntity person = OrcidProvider.getPerson("https://notorcid.org/1234");
+    });
+  }
+
+  @Test
+  void testInvalidOrcidId() {
+    PersonEntity person = OrcidProvider.getPerson("https://orcid.org/42");
+    assertNull(person);
+  }
+
 }

--- a/src/test/java/edu/kit/crate/externalproviders/RorProviderTest.java
+++ b/src/test/java/edu/kit/crate/externalproviders/RorProviderTest.java
@@ -14,23 +14,23 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @author Nikola Tzotchev on 11.2.2022 г.
  * @version 1
  */
-public class RORProviderTest {
+public class RorProviderTest {
 
   @Test
-  void testExternalRORProvider() throws IOException {
+  void testExternalRorProvider() throws IOException {
     OrganizationEntity organizationEntity = RorProvider.getOrganization("https://ror.org/04t3en479");
     HelpFunctions.compareEntityWithFile(organizationEntity, "/json/entities/contextual/rorkit.json");
   }
 
   @Test
-  void testInvalidRORUrl() {
+  void testInvalidRorUrl() {
     Exception exception = assertThrows(IllegalArgumentException.class, () -> {
       OrganizationEntity organizationEntity = RorProvider.getOrganization("https://notror.org/04t3en479");
     });
   }
 
   @Test
-  void testInvalidRORId() {
+  void testInvalidRorId() {
     OrganizationEntity organizationEntity = RorProvider.getOrganization("https://ror.org/42");
     assertNull(organizationEntity);
   }

--- a/src/test/java/edu/kit/crate/externalproviders/RorProviderTest.java
+++ b/src/test/java/edu/kit/crate/externalproviders/RorProviderTest.java
@@ -7,6 +7,9 @@ import java.io.IOException;
 import edu.kit.crate.HelpFunctions;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 /**
  * @author Nikola Tzotchev on 11.2.2022 г.
  * @version 1
@@ -17,5 +20,18 @@ public class RORProviderTest {
   void testExternalRORProvider() throws IOException {
     OrganizationEntity organizationEntity = RorProvider.getOrganization("https://ror.org/04t3en479");
     HelpFunctions.compareEntityWithFile(organizationEntity, "/json/entities/contextual/rorkit.json");
+  }
+
+  @Test
+  void testInvalidRORUrl() {
+    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+      OrganizationEntity organizationEntity = RorProvider.getOrganization("https://notror.org/04t3en479");
+    });
+  }
+
+  @Test
+  void testInvalidRORId() {
+    OrganizationEntity organizationEntity = RorProvider.getOrganization("https://ror.org/42");
+    assertNull(organizationEntity);
   }
 }


### PR DESCRIPTION
`startsWith` is ~50x faster than `matches` in those cases (just did a very quick and dirty local benchmark) and it makes the code a bit more readable in my opinion.

I also added a test to cover the `startsWith` cases and also to cover wrong ids in the RorProvider and OrcidProvider classes. Both are now at 100% test coverage:))

Also renamed the tests to match the used class names.

How does this @author thing work? Do I need to add myself now?