### PR TITLE
Add test coverage and PR report

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -41,4 +41,30 @@ jobs:
         arguments: build
         # - name: Execute Gradle test
         #run: ./gradlew test --tests PreviewTest
+    - name: Upload Test Results
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: Test Results (Gradle ${{ matrix.jdk }})
+        path: build/reports/jacoco/test/jacocoTestReport.xml
+
+  publish-test-results:
+    name: "Publish Test Results"
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+    if: always()
+
+    steps:
+    - name: Download Artifacts
+      uses: actions/download-artifact@v2
+      with:
+        path: artifacts
+    - name: Publish Test Coverage Results
+      uses: madrapps/jacoco-report@v1.2
+      with:
+        # We only show the coverage from one of the Gradle 17 runs, they should all be the same anyway
+        paths: "artifacts/Test Results (Gradle 17)/jacocoTestReport.xml"
+        token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'jvm-test-suite'
+    id 'jacoco'
 }
 
 group 'org.example'
@@ -38,7 +39,7 @@ sourceSets {
 
     test {
         java {
-           // compileClasspath += sourceSets.main.output
+            // compileClasspath += sourceSets.main.output
             //runtimeClasspath += sourceSets.main.output
             srcDirs = ['src/test/java']
         }
@@ -99,6 +100,20 @@ task performanceReadWriteMultipleCratesBenchmark(type: JavaExec) {
 }
 test {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
 }
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        csv.required = true
+        xml.required = true
+    }
+}
+
+jacoco {
+    toolVersion = "0.8.8"
+}
+
 // maxParallelForks(2)
 // failFast = true


### PR DESCRIPTION
Added jacoco test coverage to gradle and a [Github action](https://github.com/Madrapps/jacoco-report) to publish test results as comments on PRs. Looks like this:
![image](https://user-images.githubusercontent.com/26679776/172439024-63d0f22d-c225-46bd-912a-17f588dc4370.png)
