### PR TITLE
[Fix] RorProvider throws NPE in case of nonexistent identifiers.

### DIFF
--- a/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/organizationprovider/RorProvider.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/organizationprovider/RorProvider.java
@@ -33,6 +33,9 @@ public class RorProvider {
 
     try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
         CloseableHttpResponse response = httpClient.execute(request);
+        if (response.getStatusLine().getStatusCode() != 200) {
+          throw new IOException(String.format("Identifier not found: %s", response.getStatusLine().toString()));
+        }
         ObjectNode jsonNode = MyObjectMapper.getMapper().readValue(response.getEntity().getContent(),
             ObjectNode.class);
         return new OrganizationEntity.OrganizationEntityBuilder()


### PR DESCRIPTION
There seemed to be some kind of change on the side of ROR which breaks the current mechanism. Instead of an organization being null, a null pointer exception was thrown unexpectedly.