### PR TITLE
Feat: add deleteUrlFromContext

### DIFF
--- a/src/main/java/edu/kit/datamanager/ro_crate/Crate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/Crate.java
@@ -56,5 +56,7 @@ public interface Crate {
 
   public void deleteValuePairFromContext(String key);
 
+  public void deleteUrlFromContext(String url);
+
   List<File> getUntrackedFiles();
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
@@ -179,6 +179,11 @@ public class RoCrate implements Crate {
   }
 
   @Override
+  public void deleteUrlFromContext(String key) {
+    this.metadataContext.deleteUrlFromContext(key);
+  }
+
+  @Override
   public void addFromCollection(Collection<AbstractEntity> entities) {
     this.roCratePayload.addEntities(entities);
   }

--- a/src/main/java/edu/kit/datamanager/ro_crate/context/CrateMetadataContext.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/context/CrateMetadataContext.java
@@ -23,4 +23,6 @@ public interface CrateMetadataContext {
   void addToContext(String key, String value);
 
   void deleteValuePairFromContext(String key);
+
+  void deleteUrlFromContext(String url);
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
@@ -198,4 +198,10 @@ public class RoCrateMetadataContext implements CrateMetadataContext {
     this.contextMap.remove(key);
     this.other.remove(key);
   }
+
+  @Override
+  public void deleteUrlFromContext(String url) {
+    this.url.remove(url);
+  }
+
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
@@ -10,9 +10,10 @@ import edu.kit.datamanager.ro_crate.entities.AbstractEntity;
 import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -28,23 +29,20 @@ import org.apache.http.impl.client.HttpClients;
  */
 public class RoCrateMetadataContext implements CrateMetadataContext {
 
-  private static final String DEFAULT_CONTEXT = "https://w3id.org/ro/crate/1.1/context";
-  private static final String DEFAULT_CONTEXT_LOCATION = "default_context/version1.1.json";
-  private static JsonNode defaultContext = null;
+  protected static final String DEFAULT_CONTEXT = "https://w3id.org/ro/crate/1.1/context";
+  protected static final String DEFAULT_CONTEXT_LOCATION = "default_context/version1.1.json";
+  protected static JsonNode defaultContext = null;
 
-  private final List<String> url;
-  private final HashMap<String, String> contextMap;
+  protected final Set<String> url = new HashSet<>();
+  protected final HashMap<String, String> contextMap = new HashMap<>();
   // we need to keep the ones that are no coming from url
   // for the final representation
-  private final HashMap<String, String> other;
+  protected final HashMap<String, String> other = new HashMap<>();
 
   /**
    * Default constructor for the creation of the default context.
    */
   public RoCrateMetadataContext() {
-    this.url = new ArrayList<>();
-    this.contextMap = new HashMap<>();
-    this.other = new HashMap<>();
     this.addToContextFromUrl(DEFAULT_CONTEXT);
   }
 
@@ -54,9 +52,6 @@ public class RoCrateMetadataContext implements CrateMetadataContext {
    * @param url the url list with different context.
    */
   public RoCrateMetadataContext(List<String> url) {
-    this.url = new ArrayList<>();
-    this.contextMap = new HashMap<>();
-    this.other = new HashMap<>();
     for (String e : url) {
       this.addToContextFromUrl(e);
     }
@@ -68,9 +63,6 @@ public class RoCrateMetadataContext implements CrateMetadataContext {
    * @param context the Json object of the context.
    */
   public RoCrateMetadataContext(JsonNode context) {
-    this.url = new ArrayList<>();
-    this.other = new HashMap<>();
-    this.contextMap = new HashMap<>();
 
     Consumer<JsonNode> addPairs = x -> {
       var iterate = x.fields();
@@ -104,7 +96,7 @@ public class RoCrateMetadataContext implements CrateMetadataContext {
     for (String e : url) {
       array.add(e);
     }
-    for (HashMap.Entry<String, String> s : other.entrySet()) {
+    for (Map.Entry<String, String> s : other.entrySet()) {
       jsonNode.put(s.getKey(), s.getValue());
     }
     if (!jsonNode.isEmpty()) {

--- a/src/test/java/edu/kit/datamanager/ro_crate/context/ContextTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/context/ContextTest.java
@@ -1,5 +1,6 @@
 package edu.kit.datamanager.ro_crate.context;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -132,6 +133,26 @@ public class ContextTest {
 
     HelpFunctions.compare(context.getContextJsonEntity(), emptyContext.getContextJsonEntity(), true);
 
+  }
+
+  @Test
+  void doubledContextUrlsTest() throws JsonProcessingException {
+    String url = "www.example.com";
+    RoCrateMetadataContext context = new RoCrateMetadataContext();
+    assertFalse(context.url.contains(url));
+    context.addToContextFromUrl(url);
+    assertTrue(context.url.contains(url));
+
+    RoCrateMetadataContext contextDoubled = new RoCrateMetadataContext();
+    contextDoubled.addToContextFromUrl(url);
+    contextDoubled.addToContextFromUrl(url);
+    
+    HelpFunctions.compare(context.getContextJsonEntity(), contextDoubled.getContextJsonEntity(), true);
+
+    RoCrateMetadataContext emptyContext = new RoCrateMetadataContext();
+    contextDoubled.deleteUrlFromContext(url);
+
+    HelpFunctions.compare(emptyContext.getContextJsonEntity(), contextDoubled.getContextJsonEntity(), true);
   }
 
   @Test

--- a/src/test/java/edu/kit/datamanager/ro_crate/context/ContextTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/context/ContextTest.java
@@ -112,6 +112,39 @@ public class ContextTest {
   }
 
   @Test
+  void deleteNonExistingPairTest() {
+    RoCrateMetadataContext context = new RoCrateMetadataContext();
+    RoCrateMetadataContext emptyContext = new RoCrateMetadataContext();
+
+    context.deleteValuePairFromContext("key");
+
+    HelpFunctions.compare(context.getContextJsonEntity(), emptyContext.getContextJsonEntity(), true);
+  }
+
+  @Test
+  void deleteUrlTest() {
+    RoCrateMetadataContext context = new RoCrateMetadataContext();
+    RoCrateMetadataContext emptyContext = new RoCrateMetadataContext();
+
+    context.addToContextFromUrl("www.example.com");
+
+    context.deleteUrlFromContext("www.example.com");
+
+    HelpFunctions.compare(context.getContextJsonEntity(), emptyContext.getContextJsonEntity(), true);
+
+  }
+
+  @Test
+  void deleteNonExistentUrlTest() {
+    RoCrateMetadataContext context = new RoCrateMetadataContext();
+    RoCrateMetadataContext emptyContext = new RoCrateMetadataContext();
+
+    context.deleteUrlFromContext("www.example.com");
+
+    HelpFunctions.compare(context.getContextJsonEntity(), emptyContext.getContextJsonEntity(), true);
+  }
+
+  @Test
   void creationFromUrlAndPairsTest() {
 
     var objectMapper = MyObjectMapper.getMapper();

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/TestRemoveAddContext.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/TestRemoveAddContext.java
@@ -18,4 +18,16 @@ public class TestRemoveAddContext {
     HelpFunctions.compareTwoCrateJson(crate, defaultCrate);
 
   }
+
+  @Test
+  void testAddRemoveUrl() throws JsonProcessingException {
+    RoCrate crate = new RoCrate.RoCrateBuilder().addUrlToContext("https://example.com").build();
+    RoCrate defaultCrate = new RoCrate.RoCrateBuilder().build();
+
+    crate.deleteUrlFromContext("https://example.com");
+
+    HelpFunctions.compareTwoCrateJson(crate, defaultCrate);
+
+  }
+
 }


### PR DESCRIPTION
- Added deleteUrlFromContext
- Added test to make sure that deleting pairs also works if the pair isn't existing

Note: I really don't like this super shallow API design. Just passing through the command to RoCrateMetadataContext isnt making anything better imo