### PR TITLE
Fix RoCrate default constructor.

### DIFF
--- a/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
@@ -33,6 +33,7 @@ import java.util.List;
 public class RoCrate implements Crate {
 
   private static final String ID = "ro-crate-metadata.json";
+  private static final String RO_SPEC = "https://w3id.org/ro/crate/1.1";
 
   private final CratePayload roCratePayload;
   private CrateMetadataContext metadataContext;
@@ -205,7 +206,7 @@ public class RoCrate implements Crate {
         .setId(ID)
         .addType("CreativeWork")
         .addIdProperty("about", "./")
-        .addIdProperty("conformsTo", RoCrateMetadataContext.DEFAULT_CONTEXT)
+        .addIdProperty("conformsTo", RoCrate.RO_SPEC)
         .build();
   }
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
@@ -33,7 +33,6 @@ import java.util.List;
 public class RoCrate implements Crate {
 
   private static final String ID = "ro-crate-metadata.json";
-  private static final String RO_SPEC = "https://w3id.org/ro/crate/1.1";
 
   private final CratePayload roCratePayload;
   private CrateMetadataContext metadataContext;
@@ -77,8 +76,11 @@ public class RoCrate implements Crate {
    */
   public RoCrate() {
     this.roCratePayload = new RoCratePayload();
-    this.metadataContext = new RoCrateMetadataContext();
     this.untrackedFiles = new ArrayList<>();
+    this.metadataContext = new RoCrateMetadataContext();
+    rootDataEntity = new RootDataEntity.RootDataEntityBuilder()
+        .build();
+    jsonDescriptor = createDefaultJsonDescriptor();
   }
 
   /**
@@ -198,6 +200,15 @@ public class RoCrate implements Crate {
     return this.untrackedFiles;
   }
 
+  protected static ContextualEntity createDefaultJsonDescriptor() {
+    return new ContextualEntity.ContextualEntityBuilder()
+        .setId(ID)
+        .addType("CreativeWork")
+        .addIdProperty("about", "./")
+        .addIdProperty("conformsTo", RoCrateMetadataContext.DEFAULT_CONTEXT)
+        .build();
+  }
+
   /**
    * The inner class builder for the easier creation of a ROCrate.
    */
@@ -225,12 +236,7 @@ public class RoCrate implements Crate {
           .addProperty("name", name)
           .addProperty("description", description)
           .build();
-      jsonDescriptor = new ContextualEntity.ContextualEntityBuilder()
-          .setId(ID)
-          .addType("CreativeWork")
-          .addIdProperty("about", "./")
-          .addIdProperty("conformsTo", RO_SPEC)
-          .build();
+      jsonDescriptor = RoCrate.createDefaultJsonDescriptor();
     }
 
     /**
@@ -243,12 +249,7 @@ public class RoCrate implements Crate {
       this.metadataContext = new RoCrateMetadataContext();
       rootDataEntity = new RootDataEntity.RootDataEntityBuilder()
           .build();
-      jsonDescriptor = new ContextualEntity.ContextualEntityBuilder()
-          .setId(ID)
-          .addType("CreativeWork")
-          .addIdProperty("about", "./")
-          .addIdProperty("conformsTo", RO_SPEC)
-          .build();
+      jsonDescriptor = RoCrate.createDefaultJsonDescriptor();
     }
 
     /**

--- a/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
@@ -29,7 +29,7 @@ import org.apache.http.impl.client.HttpClients;
  */
 public class RoCrateMetadataContext implements CrateMetadataContext {
 
-  protected static final String DEFAULT_CONTEXT = "https://w3id.org/ro/crate/1.1/context";
+  public static final String DEFAULT_CONTEXT = "https://w3id.org/ro/crate/1.1/context";
   protected static final String DEFAULT_CONTEXT_LOCATION = "default_context/version1.1.json";
   protected static JsonNode defaultContext = null;
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
@@ -92,6 +92,14 @@ public class AbstractEntity {
   }
 
   /**
+   * Returns the types of this entity.
+   * @return a set of type strings.
+   */
+  public Set<String> getTypes() {
+    return types;
+  }
+
+  /**
    * Returns a Json object containing the properties of the entity.
    *
    * @return ObjectNode representing the properties.

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/BuilderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/BuilderTest.java
@@ -1,5 +1,7 @@
 package edu.kit.datamanager.ro_crate.crate;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -21,10 +23,21 @@ public class BuilderTest {
         .build();
 
     RoCrate crate = new RoCrate.RoCrateBuilder().addContextualEntity(license).build();
-
     RoCrate crate1 = new RoCrate.RoCrateBuilder(crate).build();
 
+    assertEquals(crate.getAllDataEntities(), crate1.getAllDataEntities());
+    assertEquals(crate.getAllContextualEntities(), crate1.getAllContextualEntities());
     HelpFunctions.compareTwoCrateJson(crate1, crate);
 
+  }
+
+  @Test
+  void testEmptyCrates() throws JsonProcessingException {
+    RoCrate built = new RoCrate.RoCrateBuilder().build();
+    RoCrate constructed = new RoCrate();
+
+    assertEquals(built.getAllDataEntities(), constructed.getAllDataEntities());
+    assertEquals(built.getAllContextualEntities(), constructed.getAllContextualEntities());
+    HelpFunctions.compareTwoCrateJson(built, constructed);
   }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/BuilderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/BuilderTest.java
@@ -38,6 +38,8 @@ public class BuilderTest {
 
     assertEquals(built.getAllDataEntities(), constructed.getAllDataEntities());
     assertEquals(built.getAllContextualEntities(), constructed.getAllContextualEntities());
+    assertEquals(built.getJsonDescriptor().getTypes(), constructed.getJsonDescriptor().getTypes());
+    assertEquals(built.getJsonDescriptor().getProperties(), constructed.getJsonDescriptor().getProperties());
     HelpFunctions.compareTwoCrateJson(built, constructed);
   }
 }


### PR DESCRIPTION
This is related to #35, and fixes it for 1.x.x series. For the next major version, we currently plan to enforce the use of the builder.

This commit also contains some small cleanup changes to avoid duplicated code.