### PR TITLE
Add missing copyright owner

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2022 kitdatamanager
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Just saw that the license was missing the copyright owner and year. I just copied the owner from other repositories of this organization such as [pit-service](https://github.com/kit-data-manager/pit-service/blob/master/LICENSE)