### PR TITLE
Use correct benchmark main class paths.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,42 +80,42 @@ configurations {
 task performanceContextEntitiesBenchmark(type: JavaExec) {
     description = "Run the context entities benchmarks."
     classpath = sourceSets.performanceTest.runtimeClasspath
-    mainClass = 'edu.kit.crate.singlecratebenchmarks.ContextualEntitiesPerformance'
+    mainClass = 'edu.kit.datamanager.ro_crate.singlecratebenchmarks.ContextualEntitiesPerformance'
 }
 
 task performanceLocalDataEntitiesBenchmark(type: JavaExec) {
     description = "Run the local data entities benchmarks."
     classpath = sourceSets.performanceTest.runtimeClasspath
-    mainClass = 'edu.kit.crate.singlecratebenchmarks.LocalDataEntitiesPerformance'
+    mainClass = 'edu.kit.datamanager.ro_crate.singlecratebenchmarks.LocalDataEntitiesPerformance'
 }
 
 task performanceRemoteDataEntitiesBenchmark(type: JavaExec) {
     description = "Run the remote data entities benchmarks."
     classpath = sourceSets.performanceTest.runtimeClasspath
-    mainClass = 'edu.kit.crate.singlecratebenchmarks.RemoteDataEntitiesPerformance'
+    mainClass = 'edu.kit.datamanager.ro_crate.singlecratebenchmarks.RemoteDataEntitiesPerformance'
 }
 
 task performanceMixEntitiesBenchmark(type: JavaExec) {
     description = "Run the remote data entities benchmarks."
     classpath = sourceSets.performanceTest.runtimeClasspath
-    mainClass = 'edu.kit.crate.singlecratebenchmarks.MixtureOfEntitiesPerformance'
+    mainClass = 'edu.kit.datamanager.ro_crate.singlecratebenchmarks.MixtureOfEntitiesPerformance'
 }
 task performanceDeletionEntitiesBenchmark(type: JavaExec) {
     description = "Run the remote data entities benchmarks."
     classpath = sourceSets.performanceTest.runtimeClasspath
-    mainClass = 'edu.kit.crate.singlecratebenchmarks.DeletionEntitiesPerformance'
+    mainClass = 'edu.kit.datamanager.ro_crate.singlecratebenchmarks.DeletionEntitiesPerformance'
 }
 
 task performanceMultipleCratesBenchmark(type: JavaExec) {
     description = "Run the remote data entities benchmarks."
     classpath = sourceSets.performanceTest.runtimeClasspath
-    mainClass = 'edu.kit.crate.multiplecrates.MultipleCratesBenchmark'
+    mainClass = 'edu.kit.datamanager.ro_crate.multiplecrates.MultipleCratesBenchmark'
 }
 
 task performanceReadWriteMultipleCratesBenchmark(type: JavaExec) {
     description = "Run the remote data entities benchmarks."
     classpath = sourceSets.performanceTest.runtimeClasspath
-    mainClass = 'edu.kit.crate.multiplecrates.MultipleCratesWriteAndRead'
+    mainClass = 'edu.kit.datamanager.ro_crate.multiplecrates.MultipleCratesWriteAndRead'
 }
 test {
     useJUnitPlatform()


### PR DESCRIPTION
This issue only affected benchmarks, not the library itself.