### PR TITLE
Encode/decode DataEntity URLs and paths.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,10 @@ plugins {
 group 'edu.kit.datamanager'
 description = "A library for easy creation and modification of valid RO-Crates."
 
+println "Running gradle version: $gradle.gradleVersion"
+println "Building ${name} version: ${version}"
+println "JDK version: ${JavaVersion.current()}"
+
 repositories {
     mavenCentral()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     // JUnit setup for testing
     testImplementation(platform("org.junit:junit-bom:5.9.1"))
     testImplementation('org.junit.jupiter:junit-jupiter')
+    testImplementation('org.junit.jupiter:junit-jupiter-params')
     // JSON object mapping / (de-)serialization
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4'

--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,7 @@ repositories {
 dependencies {
     // JUnit setup for testing
     testImplementation(platform("org.junit:junit-bom:5.9.1"))
-    testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation('org.junit.jupiter:junit-jupiter')
     // JSON object mapping / (de-)serialization
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4'

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
@@ -14,6 +14,7 @@ import edu.kit.datamanager.ro_crate.entities.validation.JsonSchemaValidation;
 import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
 import edu.kit.datamanager.ro_crate.payload.Observer;
 import edu.kit.datamanager.ro_crate.special.JsonUtilFunctions;
+import static edu.kit.datamanager.ro_crate.special.UriUtil.isEncoded;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -21,7 +22,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-
 
 /**
  * Abstract Entity parent class of every singe item in the json metadata file.
@@ -31,424 +31,429 @@ import java.util.UUID;
  */
 public class AbstractEntity {
 
-  /**
-   * This set contains the types of an entity (ex. File, Dataset, ect.) It is a set because it does
-   * not make sense to have duplicates
-   */
-  @JsonIgnore
-  private Set<String> types;
-
-  /**
-   * Contains the whole list of properties of the entity It uses a custom serializer because of
-   * cases where a single array element should be displayed as a single value. ex: "key" : ["value"]
-   * <=> "key" : "value"
-   */
-  @JsonUnwrapped
-  @JsonSerialize(using = ObjectNodeSerializer.class)
-  private ObjectNode properties;
-
-  private static final EntityValidation entityValidation
-      = new EntityValidation(new JsonSchemaValidation());
-
-
-  @JsonIgnore
-  private final Set<String> linkedTo;
-
-
-  @JsonIgnore
-  private final List<Observer> observers;
-
-  public void addObserver(Observer observer) {
-    this.observers.add(observer);
-  }
-
-  private void notifyObservers() {
-    for (var obs : this.observers) {
-      obs.update(this.getId());
-    }
-  }
-
-  /**
-   * Constructor that takes a builder and instantiates all the fields from it.
-   *
-   * @param entityBuilder the entity builder passed to the constructor.
-   */
-  public AbstractEntity(AbstractEntityBuilder<?> entityBuilder) {
-    this.types = entityBuilder.types;
-    this.properties = entityBuilder.properties;
-    this.linkedTo = entityBuilder.relatedItems;
-    this.observers = new ArrayList<>();
-    if (this.properties.get("@id") == null) {
-      if (entityBuilder.id == null) {
-        this.properties.put("@id", UUID.randomUUID().toString());
-      } else {
-        this.properties.put("@id", entityBuilder.id);
-      }
-    }
-  }
-
-  public Set<String> getLinkedTo() {
-    return linkedTo;
-  }
-
-  /**
-   * Returns the types of this entity.
-   * @return a set of type strings.
-   */
-  public Set<String> getTypes() {
-    return types;
-  }
-
-  /**
-   * Returns a Json object containing the properties of the entity.
-   *
-   * @return ObjectNode representing the properties.
-   */
-  public ObjectNode getProperties() {
-    if (this.types != null) {
-      JsonNode node = MyObjectMapper.getMapper().valueToTree(this.types);
-      this.properties.set("@type", node);
-    }
-    return properties;
-  }
-
-  public JsonNode getProperty(String propertyKey) {
-    return this.properties.get(propertyKey);
-  }
-
-  @JsonIgnore
-  public String getId() {
-    JsonNode id = this.properties.get("@id");
-    return id == null ? null : id.asText();
-  }
-
-  /**
-   * Set all the properties from a Json object to the Entity.
-   * The entities are first validated to filter any invalid entity properties.
-   *
-   * @param obj the object that contains all the json properties that should be added.
-   */
-  public void setProperties(JsonNode obj) {
-    // validate whole entity
-    if (entityValidation.entityValidation(obj)) {
-      this.properties = obj.deepCopy();
-      this.notifyObservers();
-    }
-  }
-
-  protected void setId(String id) {
-    this.properties.put("@id", id);
-  }
-
-  /**
-   * Add a JSON property to the entity.
-   * Here the value of the property is a String.
-   *
-   * @param key   the name of the property (term).
-   * @param value the value that the property has.
-   */
-  public void addProperty(String key, String value) {
-    if (key != null && value != null) {
-      this.properties.put(key, value);
-      this.notifyObservers();
-    }
-  }
-
-  /**
-   * This is another way of adding a property,
-   * this time the value is a long integer.
-   *
-   * @param key   the String key of the property.
-   * @param value the long value.
-   */
-  public void addProperty(String key, long value) {
-    if (key != null) {
-      this.properties.put(key, value);
-      this.notifyObservers();
-    }
-  }
-
-  /**
-   * Another way of adding a property this time the value is a double.
-   *
-   * @param key   the string key of the property.
-   * @param value double value of the property.
-   */
-  public void addProperty(String key, double value) {
-    if (key != null) {
-      this.properties.put(key, value);
-      this.notifyObservers();
-    }
-  }
-
-  /**
-   * This is the most generic way of adding a property.
-   * The value is a JsonNode that could contain anything possible.
-   * This is way firstly it is validated that it follows the correct guidelines.
-   *
-   * @param key   String key of the property.
-   * @param value The JsonNode representing the value.
-   */
-  public void addProperty(String key, JsonNode value) {
-    if (addProperty(this.properties, key, value)) {
-      notifyObservers();
-    }
-  }
-
-  private static boolean addProperty(ObjectNode whereToAdd, String key, JsonNode value) {
-    boolean validInput = key != null && value != null;
-    if (validInput && entityValidation.fieldValidation(value)) {
-      whereToAdd.set(key, value);
-      return true;
-    }
-    return false;
-  }
-
-  /**
-   * Add a property that looks like this:
-   * "name" : {"@id" : "id"}
-   * If the name property already exists add a second @id to it.
-   *
-   * @param name the "key" of the property.
-   * @param id   the "id" of the property.
-   */
-  public void addIdProperty(String name, String id) {
-    JsonNode jsonNode = addToIdProperty(name, id, this.properties.get(name));
-    if (jsonNode != null) {
-      this.linkedTo.add(id);
-      this.properties.set(name, jsonNode);
-      this.notifyObservers();
-    }
-  }
-
-  private static JsonNode addToIdProperty(String name, String id, JsonNode property) {
-    ObjectMapper objectMapper = MyObjectMapper.getMapper();
-    if (name != null && id != null) {
-      if (property == null) {
-        return objectMapper.createObjectNode().put("@id", id);
-      } else {
-        if (property.isArray()) {
-          ArrayNode ns = (ArrayNode) property;
-          ns.add(objectMapper.createObjectNode().put("@id", id));
-          return ns;
-        } else {
-          ArrayNode newNodes = objectMapper.createArrayNode();
-          newNodes.add(property);
-          newNodes.add(objectMapper.createObjectNode().put("@id", id));
-          return newNodes;
-        }
-      }
-    }
-    return null;
-  }
-
-  /**
-   * Adds everything from the stringList to the property "name" as id.
-   *
-   * @param name       the key of the property.
-   * @param stringList List containing all the id as String.
-   */
-  public void addIdListProperties(String name, List<String> stringList) {
-    ObjectMapper objectMapper = MyObjectMapper.getMapper();
-    ArrayNode node = objectMapper.createArrayNode();
-    if (this.properties.get(name) == null) {
-      node = objectMapper.createArrayNode();
-    } else {
-      if (!this.properties.get(name).isArray()) {
-        node.add(this.properties.get(name));
-      }
-    }
-    for (String s : stringList) {
-      this.linkedTo.add(s);
-      node.add(objectMapper.createObjectNode().put("@id", s));
-    }
-    if (node.size() == 1) {
-      this.properties.set(name, node.get(0));
-    } else {
-      this.properties.set(name, node);
-    }
-    notifyObservers();
-  }
-
-  /**
-   * Adding new type to the property (which may have multiple such ones).
-   *
-   * @param type the String representing the type.
-   */
-  public void addType(String type) {
-    if (this.types == null) {
-      this.types = new HashSet<>();
-    }
-    this.types.add(type);
-    JsonNode node = MyObjectMapper.getMapper().valueToTree(this.types);
-    this.properties.set("@type", node);
-  }
-
-  /**
-   * This a builder inner class that should allow for an easier creating of entities.
-   *
-   * @param <T> The type of the child builders so that they to can use the methods provided here.
-   */
-  public abstract static class AbstractEntityBuilder<T extends AbstractEntityBuilder<T>> {
-
+    /**
+     * This set contains the types of an entity (ex. File, Dataset, ect.) It is
+     * a set because it does not make sense to have duplicates
+     */
+    @JsonIgnore
     private Set<String> types;
-    protected Set<String> relatedItems;
+
+    /**
+     * Contains the whole list of properties of the entity It uses a custom
+     * serializer because of cases where a single array element should be
+     * displayed as a single value. ex: "key" : ["value"]
+     * <=> "key" : "value"
+     */
+    @JsonUnwrapped
+    @JsonSerialize(using = ObjectNodeSerializer.class)
     private ObjectNode properties;
-    private String id;
 
-    protected AbstractEntityBuilder() {
-      this.properties = MyObjectMapper.getMapper().createObjectNode();
-      this.relatedItems = new HashSet<>();
+    private static final EntityValidation entityValidation
+            = new EntityValidation(new JsonSchemaValidation());
+
+    @JsonIgnore
+    private final Set<String> linkedTo;
+
+    @JsonIgnore
+    private final List<Observer> observers;
+
+    public void addObserver(Observer observer) {
+        this.observers.add(observer);
     }
 
-    protected String getId() {
-      return this.id;
-    }
-
-    /**
-     * Setting the id property of the entity.
-     *
-     * @param id the String representing the id.
-     * @return the generic builder.
-     */
-    public T setId(String id) {
-      // TODO document why this has been implemented this way.
-      if (id != null) {
-        this.id = id;
-      }
-      return self();
-    }
-
-    /**
-     * Adding a type to the builder types.
-     *
-     * @param type the type to add.
-     * @return the generic builder.
-     */
-    public T addType(String type) {
-      if (this.types == null) {
-        this.types = new HashSet<>();
-      }
-      this.types.add(type);
-      return self();
-    }
-
-    /**
-     * Adding multiple types as list.
-     *
-     * @param types the types in a String List.
-     * @return the generic builder.
-     */
-    public T addTypes(List<String> types) {
-      if (this.types == null) {
-        this.types = new HashSet<>();
-      }
-      this.types.addAll(types);
-      return self();
-    }
-
-    /**
-     * Adding a property to the builder.
-     *
-     * @param key the key of the property in a string.
-     * @param value the JsonNode value of te property.
-     * @return the generic builder.
-     */
-    public T addProperty(String key, JsonNode value) {
-      if (AbstractEntity.addProperty(this.properties, key, value)) {
-        this.relatedItems.addAll(JsonUtilFunctions.getIdPropertiesFromProperty(value));
-      }
-      return self();
-    }
-
-    public T addProperty(String key, String value) {
-      this.properties.put(key, value);
-      return self();
-    }
-
-    public T addProperty(String key, int value) {
-      this.properties.put(key, value);
-      return self();
-    }
-
-    public T addProperty(String key, double value) {
-      this.properties.put(key, value);
-      return self();
-    }
-
-    public T addProperty(String key, boolean value) {
-      this.properties.put(key, value);
-      return self();
-    }
-    /**
-     * ID properties are often used when referencing other entities within the ROCrate.
-     * This method adds automatically such one.
-     * Instead of:
-     *  "name": "id"
-     * added is :
-     *  "name" : {"@id": "id"}
-     *
-     * @param name the name of the ID property.
-     * @param id the ID.
-     * @return the generic builder
-     */
-    public T addIdProperty(String name, String id) {
-      JsonNode jsonNode = AbstractEntity.addToIdProperty(name, id, this.properties.get(name));
-      if (jsonNode != null) {
-        this.properties.set(name, jsonNode);
-        this.relatedItems.add(id);
-      }
-      return self();
-    }
-
-    /**
-     * This is another way of adding the ID property, this time the whole other Entity is provided.
-     *
-     * @param name the name of the property.
-     * @param entity the other entity that is referenced.
-     * @return the generic builder.
-     */
-    public T addIdProperty(String name, AbstractEntity entity) {
-      if (entity != null) {
-        return addIdProperty(name, entity.getId());
-      }
-      return self();
-    }
-
-    /**
-     * This adds multiple id entities to a single key.
-     *
-     * @param name the name of the property.
-     * @param entities the Collection containing the multiple entities.
-     * @return the generic builder.
-     */
-    public T addIdFromCollectionOfEntities(String name, Collection<AbstractEntity> entities) {
-      if (entities != null) {
-        for (var e : entities) {
-          addIdProperty(name, e);
+    private void notifyObservers() {
+        for (var obs : this.observers) {
+            obs.update(this.getId());
         }
-      }
-      return self();
     }
 
     /**
-     * This sets everything from a json object to the property.
-     * Can be useful when the entity is already available somewhere.
+     * Constructor that takes a builder and instantiates all the fields from it.
      *
-     * @param properties the Json representing all the properties.
-     * @return the generic builder.
+     * @param entityBuilder the entity builder passed to the constructor.
      */
-    public T setAll(ObjectNode properties) {
-      if (AbstractEntity.entityValidation.entityValidation(properties)) {
-        this.properties = properties;
-        this.relatedItems.addAll(JsonUtilFunctions.getIdPropertiesFromJsonNode(properties));
-      }
-      return self();
+    public AbstractEntity(AbstractEntityBuilder<?> entityBuilder) {
+        this.types = entityBuilder.types;
+        this.properties = entityBuilder.properties;
+        this.linkedTo = entityBuilder.relatedItems;
+        this.observers = new ArrayList<>();
+        if (this.properties.get("@id") == null) {
+            if (entityBuilder.id == null) {
+                this.properties.put("@id", UUID.randomUUID().toString());
+            } else {
+                this.properties.put("@id", entityBuilder.id);
+            }
+        }
     }
 
-    public abstract T self();
+    public Set<String> getLinkedTo() {
+        return linkedTo;
+    }
 
-    public abstract AbstractEntity build();
-  }
+    /**
+     * Returns the types of this entity.
+     *
+     * @return a set of type strings.
+     */
+    public Set<String> getTypes() {
+        return types;
+    }
+
+    /**
+     * Returns a Json object containing the properties of the entity.
+     *
+     * @return ObjectNode representing the properties.
+     */
+    public ObjectNode getProperties() {
+        if (this.types != null) {
+            JsonNode node = MyObjectMapper.getMapper().valueToTree(this.types);
+            this.properties.set("@type", node);
+        }
+        return properties;
+    }
+
+    public JsonNode getProperty(String propertyKey) {
+        return this.properties.get(propertyKey);
+    }
+
+    @JsonIgnore
+    public String getId() {
+        JsonNode id = this.properties.get("@id");
+        return id == null ? null : id.asText();
+    }
+
+    /**
+     * Set all the properties from a Json object to the Entity. The entities are
+     * first validated to filter any invalid entity properties.
+     *
+     * @param obj the object that contains all the json properties that should
+     * be added.
+     */
+    public void setProperties(JsonNode obj) {
+        // validate whole entity
+        if (entityValidation.entityValidation(obj)) {
+            this.properties = obj.deepCopy();
+            this.notifyObservers();
+        }
+    }
+
+    protected void setId(String id) {
+        this.properties.put("@id", id);
+    }
+
+    /**
+     * Add a JSON property to the entity. Here the value of the property is a
+     * String.
+     *
+     * @param key the name of the property (term).
+     * @param value the value that the property has.
+     */
+    public void addProperty(String key, String value) {
+        if (key != null && value != null) {
+            this.properties.put(key, value);
+            this.notifyObservers();
+        }
+    }
+
+    /**
+     * This is another way of adding a property, this time the value is a long
+     * integer.
+     *
+     * @param key the String key of the property.
+     * @param value the long value.
+     */
+    public void addProperty(String key, long value) {
+        if (key != null) {
+            this.properties.put(key, value);
+            this.notifyObservers();
+        }
+    }
+
+    /**
+     * Another way of adding a property this time the value is a double.
+     *
+     * @param key the string key of the property.
+     * @param value double value of the property.
+     */
+    public void addProperty(String key, double value) {
+        if (key != null) {
+            this.properties.put(key, value);
+            this.notifyObservers();
+        }
+    }
+
+    /**
+     * This is the most generic way of adding a property. The value is a
+     * JsonNode that could contain anything possible. This is way firstly it is
+     * validated that it follows the correct guidelines.
+     *
+     * @param key String key of the property.
+     * @param value The JsonNode representing the value.
+     */
+    public void addProperty(String key, JsonNode value) {
+        if (addProperty(this.properties, key, value)) {
+            notifyObservers();
+        }
+    }
+
+    private static boolean addProperty(ObjectNode whereToAdd, String key, JsonNode value) {
+        boolean validInput = key != null && value != null;
+        if (validInput && entityValidation.fieldValidation(value)) {
+            whereToAdd.set(key, value);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Add a property that looks like this: "name" : {"@id" : "id"} If the name
+     * property already exists add a second @id to it.
+     *
+     * @param name the "key" of the property.
+     * @param id the "id" of the property.
+     */
+    public void addIdProperty(String name, String id) {
+        JsonNode jsonNode = addToIdProperty(name, id, this.properties.get(name));
+        if (jsonNode != null) {
+            this.linkedTo.add(id);
+            this.properties.set(name, jsonNode);
+            this.notifyObservers();
+        }
+    }
+
+    private static JsonNode addToIdProperty(String name, String id, JsonNode property) {
+        ObjectMapper objectMapper = MyObjectMapper.getMapper();
+        if (name != null && id != null) {
+            if (property == null) {
+                return objectMapper.createObjectNode().put("@id", id);
+            } else {
+                if (property.isArray()) {
+                    ArrayNode ns = (ArrayNode) property;
+                    ns.add(objectMapper.createObjectNode().put("@id", id));
+                    return ns;
+                } else {
+                    ArrayNode newNodes = objectMapper.createArrayNode();
+                    newNodes.add(property);
+                    newNodes.add(objectMapper.createObjectNode().put("@id", id));
+                    return newNodes;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Adds everything from the stringList to the property "name" as id.
+     *
+     * @param name the key of the property.
+     * @param stringList List containing all the id as String.
+     */
+    public void addIdListProperties(String name, List<String> stringList) {
+        ObjectMapper objectMapper = MyObjectMapper.getMapper();
+        ArrayNode node = objectMapper.createArrayNode();
+        if (this.properties.get(name) == null) {
+            node = objectMapper.createArrayNode();
+        } else {
+            if (!this.properties.get(name).isArray()) {
+                node.add(this.properties.get(name));
+            }
+        }
+        for (String s : stringList) {
+            this.linkedTo.add(s);
+            node.add(objectMapper.createObjectNode().put("@id", s));
+        }
+        if (node.size() == 1) {
+            this.properties.set(name, node.get(0));
+        } else {
+            this.properties.set(name, node);
+        }
+        notifyObservers();
+    }
+
+    /**
+     * Adding new type to the property (which may have multiple such ones).
+     *
+     * @param type the String representing the type.
+     */
+    public void addType(String type) {
+        if (this.types == null) {
+            this.types = new HashSet<>();
+        }
+        this.types.add(type);
+        JsonNode node = MyObjectMapper.getMapper().valueToTree(this.types);
+        this.properties.set("@type", node);
+    }
+
+    /**
+     * This a builder inner class that should allow for an easier creating of
+     * entities.
+     *
+     * @param <T> The type of the child builders so that they to can use the
+     * methods provided here.
+     */
+    public abstract static class AbstractEntityBuilder<T extends AbstractEntityBuilder<T>> {
+
+        private Set<String> types;
+        protected Set<String> relatedItems;
+        private ObjectNode properties;
+        private String id;
+
+        protected AbstractEntityBuilder() {
+            this.properties = MyObjectMapper.getMapper().createObjectNode();
+            this.relatedItems = new HashSet<>();
+        }
+
+        protected String getId() {
+            return this.id;
+        }
+
+        /**
+         * Setting the id property of the entity.
+         *
+         * @param id the String representing the id.
+         * @return the generic builder.
+         */
+        public T setId(String id) {
+            // TODO document why this has been implemented this way.
+            if (id != null) {
+                if (isEncoded(id)) {
+                    this.id=id;
+                } else {
+                    throw new IllegalArgumentException("The ID is not correctly encoded.");
+                }
+            }
+            return self();
+        }
+
+        /**
+         * Adding a type to the builder types.
+         *
+         * @param type the type to add.
+         * @return the generic builder.
+         */
+        public T addType(String type) {
+            if (this.types == null) {
+                this.types = new HashSet<>();
+            }
+            this.types.add(type);
+            return self();
+        }
+
+        /**
+         * Adding multiple types as list.
+         *
+         * @param types the types in a String List.
+         * @return the generic builder.
+         */
+        public T addTypes(List<String> types) {
+            if (this.types == null) {
+                this.types = new HashSet<>();
+            }
+            this.types.addAll(types);
+            return self();
+        }
+
+        /**
+         * Adding a property to the builder.
+         *
+         * @param key the key of the property in a string.
+         * @param value the JsonNode value of te property.
+         * @return the generic builder.
+         */
+        public T addProperty(String key, JsonNode value) {
+            if (AbstractEntity.addProperty(this.properties, key, value)) {
+                this.relatedItems.addAll(JsonUtilFunctions.getIdPropertiesFromProperty(value));
+            }
+            return self();
+        }
+
+        public T addProperty(String key, String value) {
+            this.properties.put(key, value);
+            return self();
+        }
+
+        public T addProperty(String key, int value) {
+            this.properties.put(key, value);
+            return self();
+        }
+
+        public T addProperty(String key, double value) {
+            this.properties.put(key, value);
+            return self();
+        }
+
+        public T addProperty(String key, boolean value) {
+            this.properties.put(key, value);
+            return self();
+        }
+
+        /**
+         * ID properties are often used when referencing other entities within
+         * the ROCrate. This method adds automatically such one. Instead of:
+         * "name": "id" added is : "name" : {"@id": "id"}
+         *
+         * @param name the name of the ID property.
+         * @param id the ID.
+         * @return the generic builder
+         */
+        public T addIdProperty(String name, String id) {
+            JsonNode jsonNode = AbstractEntity.addToIdProperty(name, id, this.properties.get(name));
+            if (jsonNode != null) {
+                this.properties.set(name, jsonNode);
+                this.relatedItems.add(id);
+            }
+            return self();
+        }
+
+        /**
+         * This is another way of adding the ID property, this time the whole
+         * other Entity is provided.
+         *
+         * @param name the name of the property.
+         * @param entity the other entity that is referenced.
+         * @return the generic builder.
+         */
+        public T addIdProperty(String name, AbstractEntity entity) {
+            if (entity != null) {
+                return addIdProperty(name, entity.getId());
+            }
+            return self();
+        }
+
+        /**
+         * This adds multiple id entities to a single key.
+         *
+         * @param name the name of the property.
+         * @param entities the Collection containing the multiple entities.
+         * @return the generic builder.
+         */
+        public T addIdFromCollectionOfEntities(String name, Collection<AbstractEntity> entities) {
+            if (entities != null) {
+                for (var e : entities) {
+                    addIdProperty(name, e);
+                }
+            }
+            return self();
+        }
+
+        /**
+         * This sets everything from a json object to the property. Can be
+         * useful when the entity is already available somewhere.
+         *
+         * @param properties the Json representing all the properties.
+         * @return the generic builder.
+         */
+        public T setAll(ObjectNode properties) {
+            if (AbstractEntity.entityValidation.entityValidation(properties)) {
+                this.properties = properties;
+                this.relatedItems.addAll(JsonUtilFunctions.getIdPropertiesFromJsonNode(properties));
+            }
+            return self();
+        }
+
+        public abstract T self();
+
+        public abstract AbstractEntity build();
+    }
 
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataEntity.java
@@ -4,19 +4,17 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import edu.kit.datamanager.ro_crate.entities.AbstractEntity;
 import edu.kit.datamanager.ro_crate.entities.contextual.ContextualEntity;
+import static edu.kit.datamanager.ro_crate.special.UriUtil.decode;
+import static edu.kit.datamanager.ro_crate.special.UriUtil.isUrl;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URLDecoder;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.exception.ZipException;
 import net.lingala.zip4j.model.ZipParameters;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.validator.routines.UrlValidator;
 
 /**
  * The base class of every data entity.
@@ -34,16 +32,15 @@ public class DataEntity extends AbstractEntity {
    *
    * @param entityBuilder the builder passed as argument.
    */
-  public DataEntity(AbstractDataEntityBuilder<?> entityBuilder) {
+  public DataEntity(AbstractDataEntityBuilder<?> entityBuilder){
     super(entityBuilder);
     if (!entityBuilder.authors.isEmpty()) {
       this.addIdListProperties("author", entityBuilder.authors);
     }
     this.source = entityBuilder.location;
-    if (this.getSource() == null) {
-      UrlValidator urlValidator = new UrlValidator();
-      if (!urlValidator.isValid(URLDecoder.decode(this.getId(), StandardCharsets.UTF_8))) {
-        System.out.println("This Data Entity remote ID does not resolve to a valid URL.");
+    if (this.getSource() == null) {  
+      if (!isUrl(decode(this.getId()).get())) {
+       throw new IllegalArgumentException("This Data Entity remote ID does not resolve to a valid URL.");
       }
     }
   }
@@ -101,7 +98,7 @@ public class DataEntity extends AbstractEntity {
     public T setSource(File file) {
       if (file != null) {
         if (this.getId() == null) {
-          this.setId(URLEncoder.encode(file.getName(), StandardCharsets.UTF_8));
+                this.setId(file.getName());
         }
         this.location = file;
       }
@@ -143,7 +140,7 @@ public class DataEntity extends AbstractEntity {
     }
 
     @Override
-    public DataEntity build() {
+    public DataEntity build(){
       return new DataEntity(this);
     }
   }

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/RoCrateReader.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/RoCrateReader.java
@@ -10,12 +10,11 @@ import edu.kit.datamanager.ro_crate.context.RoCrateMetadataContext;
 import edu.kit.datamanager.ro_crate.entities.contextual.ContextualEntity;
 import edu.kit.datamanager.ro_crate.entities.data.DataEntity;
 import edu.kit.datamanager.ro_crate.entities.data.RootDataEntity;
+import edu.kit.datamanager.ro_crate.special.UriUtil;
 import edu.kit.datamanager.ro_crate.validation.JsonSchemaValidation;
 import edu.kit.datamanager.ro_crate.validation.Validator;
 
 import java.io.File;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -101,7 +100,7 @@ public class RoCrateReader {
   }
 
   private File checkFolderHasFile(String id, File file) {
-    Path path = file.toPath().resolve(URLDecoder.decode(id, StandardCharsets.UTF_8));
+    Path path = file.toPath().resolve(UriUtil.decode(id).get());
     if (path.toFile().exists()) {
       return path.toFile();
     }

--- a/src/main/java/edu/kit/datamanager/ro_crate/special/UriUtil.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/special/UriUtil.java
@@ -1,0 +1,155 @@
+package edu.kit.datamanager.ro_crate.special;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.Optional;
+
+import org.apache.commons.validator.routines.UrlValidator;
+
+import com.apicatalog.jsonld.uri.UriUtils;
+
+/**
+ * This class defines methods regarding URIs in general, which in RO-Crate
+ * context means usually a valid, resolvable URL or a relative file path.
+ * 
+ * The purpose is to have a simple abstraction where the way e.g. a URL is
+ * checked can be changed and tested easily for the whole library.
+ */
+public class UriUtil {
+
+    /**
+     * Hidden constructor, as this class only has static methods.
+     */
+    private UriUtil() {
+    }
+
+    /**
+     * Returns true, if the given String is decoded.
+     * 
+     * @param uri the given URI. Usually a URL or relative file path.
+     * @return true if url is decoded, false if it is not.
+     */
+    public static boolean isDecoded(String uri) {
+        return !isEncoded(uri);
+    }
+
+    /**
+     * Returns true, if the given String is encoded.
+     * 
+     * @param uri the given URI. Usually a URL or relative file path.
+     * @return trie if the url is decoded, false if it is not.
+     */
+    public static boolean isEncoded(String uri) {
+        return UriUtils.isURI(uri);
+    }
+
+    /**
+     * Returns true, if the given string is a url.
+     * 
+     * @param uri the given string
+     * @return true if it is a url, false otherwise.
+     */
+    public static boolean isUrl(String uri) {
+        return asUrl(uri).isPresent();
+    }
+
+    /**
+     * Tests if the given String is a URL, and if so, returns it.
+     * 
+     * @param uri the given String which will be tested.
+     * @return the url, if it is one.
+     */
+    public static Optional<URL> asUrl(String uri) {
+        try {
+            return Optional.of(new URL(uri));
+        } catch (MalformedURLException e) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Returns true, if the given string is a path.
+     * 
+     * @param uri the given string
+     * @return true if it is a path, false otherwise.
+     */
+    public static boolean isPath(String uri) {
+        return asPath(uri).isPresent();
+    }
+
+    /**
+     * Tests if the given String is a path, and if so, returns it.
+     * 
+     * @param uri the given String which will be tested.
+     * @return the path, if it is one.
+     */
+    public static Optional<Path> asPath(String uri) {
+        try {
+            Path u = Path.of(uri);
+            if (!isUrl(uri)) {
+                return Optional.of(u);
+            }
+        } catch (InvalidPathException e) {
+            return Optional.empty();
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Encodes a string using the description if the ro-crate-specification.
+     * 
+     * @param uri the string to encode.
+     * @return the encoded version of the given string, if possible.
+     */
+    public static Optional<String> encode(String uri) {
+        if (isEncoded(uri)) {
+            return Optional.of(uri);
+        }
+
+        Optional<URL> url = asUrl(uri);
+        Optional<Path> p = asPath(uri);
+        if (url.isPresent()) {
+            try {
+                URI u = url.get().toURI();
+                return Optional.of(u.toASCIIString());
+            } catch (URISyntaxException e) {
+                return Optional.empty();
+            }
+        } else if (p.isPresent()) {
+            // according to
+            // https://www.researchobject.org/ro-crate/1.1/data-entities.html#encoding-file-paths
+            // a file path may not be fully encoded and may contain international unicode
+            // characters. So we try a "soft"-encoding first, and if this is not yet valid,
+            // we really fully encode it.
+            String result = p.get().toString();
+            result = result.replace("\\", "/");
+            result = result.replace("%", "%25");
+            result = result.replace(" ", "%20");
+            return Optional.of(result);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Returns true, if the URLs domain exists.
+     * 
+     * @param url the given URL
+     * @return true if domain exists.
+     */
+    public static boolean hasValidDomain(String url) {
+        UrlValidator validator = new UrlValidator();
+        if (isDecoded(url)) {
+            String encoded = URLEncoder.encode(url, StandardCharsets.UTF_8);
+            return validator.isValid(encoded);
+        }
+        return validator.isValid(url);
+    }
+}

--- a/src/main/java/edu/kit/datamanager/ro_crate/special/UriUtil.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/special/UriUtil.java
@@ -30,7 +30,7 @@ public class UriUtil {
     }
 
     /**
-     * Returns true, if the given String is decoded.
+     * Returns true, if the given String is decoded and can be used as an identifier in RO-Crate.
      * 
      * @param uri the given URI. Usually a URL or relative file path.
      * @return true if url is decoded, false if it is not.
@@ -40,13 +40,13 @@ public class UriUtil {
     }
 
     /**
-     * Returns true, if the given String is encoded.
+     * Returns true, if the given String is encoded and can be used as an identifier in RO-Crate.
      * 
      * @param uri the given URI. Usually a URL or relative file path.
      * @return trie if the url is encoded, false if it is not.
      */
     public static boolean isEncoded(String uri) {
-        return UriUtils.isURI(uri);
+        return UriUtils.isURI(uri) || isLdBlankNode(uri);
     }
 
     /**
@@ -108,7 +108,7 @@ public class UriUtil {
      * @return the encoded version of the given string, if possible.
      */
     public static Optional<String> encode(String uri) {
-        if (isEncoded(uri)) {
+        if (isEncoded(uri) || isLdBlankNode(uri)) {
             return Optional.of(uri);
         }
 
@@ -135,6 +135,17 @@ public class UriUtil {
         } else {
             return Optional.empty();
         }
+    }
+
+    /**
+     * Returns true if the given string is a blank node identifier in the Linked
+     * Data world.
+     * 
+     * @param uri the given String
+     * @return true if the string is a blank node. False if not.
+     */
+    private static boolean isLdBlankNode(String uri) {
+        return uri.startsWith("_:");
     }
 
     /**

--- a/src/main/java/edu/kit/datamanager/ro_crate/special/UriUtil.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/special/UriUtil.java
@@ -8,7 +8,6 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-import java.util.Iterator;
 import java.util.Optional;
 
 import org.apache.commons.validator.routines.UrlValidator;
@@ -44,7 +43,7 @@ public class UriUtil {
      * Returns true, if the given String is encoded.
      * 
      * @param uri the given URI. Usually a URL or relative file path.
-     * @return trie if the url is decoded, false if it is not.
+     * @return trie if the url is encoded, false if it is not.
      */
     public static boolean isEncoded(String uri) {
         return UriUtils.isURI(uri);

--- a/src/main/java/edu/kit/datamanager/ro_crate/special/UriUtil.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/special/UriUtil.java
@@ -131,7 +131,11 @@ public class UriUtil {
             result = result.replace("\\", "/");
             result = result.replace("%", "%25");
             result = result.replace(" ", "%20");
-            return Optional.of(result);
+            if (isEncoded(result)) {
+                return Optional.of(result);
+            } else {
+                return Optional.of(URLEncoder.encode(result, StandardCharsets.UTF_8));
+            }
         } else {
             return Optional.empty();
         }

--- a/src/main/java/edu/kit/datamanager/ro_crate/special/UriUtil.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/special/UriUtil.java
@@ -29,14 +29,14 @@ public class UriUtil {
     }
 
     /**
-     * Returns true, if the given String is decoded and can be used as an identifier
+     * Returns true, if the given String can not be used as an identifier
      * in RO-Crate.
      * 
      * @param uri the given URI. Usually a URL or relative file path.
      * @return true if url is decoded, false if it is not.
      */
-    public static boolean isDecoded(String uri) {
-        return !isEncoded(uri);
+    public static boolean isNotValidUri(String uri) {
+        return !isValidUri(uri);
     }
 
     /**
@@ -46,7 +46,7 @@ public class UriUtil {
      * @param uri the given URI. Usually a URL or relative file path.
      * @return trie if the url is encoded, false if it is not.
      */
-    public static boolean isEncoded(String uri) {
+    public static boolean isValidUri(String uri) {
         return UriUtils.isURI(uri) || isLdBlankNode(uri);
     }
 
@@ -109,7 +109,7 @@ public class UriUtil {
      * @return the encoded version of the given string, if possible.
      */
     public static Optional<String> encode(String uri) {
-        if (isEncoded(uri) || isLdBlankNode(uri)) {
+        if (isValidUri(uri) || isLdBlankNode(uri)) {
             return Optional.of(uri);
         }
         // according to
@@ -121,14 +121,14 @@ public class UriUtil {
         result = result.replace("\\", "/");
         result = result.replace("%", "%25");
         result = result.replace(" ", "%20");
-        if (isEncoded(result)) {
+        if (isValidUri(result)) {
             return Optional.of(result);
         }
         // from here on, our soft-encoding failed and we will fully encode the url or
         // path.
         result = URLEncoder.encode(result, StandardCharsets.UTF_8);
 
-        if (isEncoded(result)) {
+        if (isValidUri(result)) {
             return Optional.of(result);
         } else {
             return Optional.empty();
@@ -136,7 +136,7 @@ public class UriUtil {
     }
 
     public static Optional<String> decode(String uri) {
-        if (isEncoded(uri) || isLdBlankNode(uri)) {
+        if (isNotValidUri(uri) || isLdBlankNode(uri)) {
             return Optional.of(uri);
         }
         return Optional.of(URLDecoder.decode(uri, StandardCharsets.UTF_8));
@@ -161,7 +161,7 @@ public class UriUtil {
      */
     public static boolean hasValidDomain(String url) {
         UrlValidator validator = new UrlValidator();
-        if (isDecoded(url)) {
+        if (isNotValidUri(url)) {
             String encoded = URLEncoder.encode(url, StandardCharsets.UTF_8);
             return validator.isValid(encoded);
         }

--- a/src/test/java/edu/kit/datamanager/ro_crate/entities/contextual/PersonEntityTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/entities/contextual/PersonEntityTest.java
@@ -14,32 +14,32 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class PersonEntityTest {
 
-  @Test
-  void personSerialization() throws IOException {
-    String id = "https://orcid.org/0000-0001-6121-5409";
-    PersonEntity person = new PersonEntity.PersonEntityBuilder()
-        .setId(id)
-        .setContactPoint("mailto:tim.luckett@uts.edu.au")
-        .setAffiliation("https://ror.org/03f0f6041")
-        .setFamilyName("Luckett")
-        .setGivenName("Tim")
-        .addProperty("name", "Tim Luckett")
-        .build();
-    assertEquals(id, person.getId());
-    HelpFunctions.compareEntityWithFile(person, "/json/entities/contextual/person.json");
-  }
+    @Test
+    void personSerialization() throws IOException {
+        String id = "https://orcid.org/0000-0001-6121-5409";
+        PersonEntity person = new PersonEntity.PersonEntityBuilder()
+                .setId(id)
+                .setContactPoint("mailto:tim.luckett@uts.edu.au")
+                .setAffiliation("https://ror.org/03f0f6041")
+                .setFamilyName("Luckett")
+                .setGivenName("Tim")
+                .addProperty("name", "Tim Luckett")
+                .build();
+        assertEquals(id, person.getId());
+        HelpFunctions.compareEntityWithFile(person, "/json/entities/contextual/person.json");
+    }
 
-  // test if creating an entity without Id will get a default UUI
-  @Test
-  void personWithoutId() {
-    PersonEntity person = new PersonEntity.PersonEntityBuilder()
-        .setContactPoint("mailto:tim.luckett@uts.edu.au")
-        .setAffiliation("https://ror.org/03f0f6041")
-        .setFamilyName("Luckett")
-        .setGivenName("Tim")
-        .addProperty("name", "Tim Luckett")
-        .build();
-
-    assertFalse(person.getId().isEmpty());
-  }
+    // test if creating an entity without Id will get a default UUI
+    @Test
+    void personWithoutId() {
+        PersonEntity person = new PersonEntity.PersonEntityBuilder()
+                .setContactPoint("mailto:tim.luckett@uts.edu.au")
+                .setAffiliation("https://ror.org/03f0f6041")
+                .setFamilyName("Luckett")
+                .setGivenName("Tim")
+                .addProperty("name", "Tim Luckett")
+                .build();
+        
+        assertFalse(person.getId().isEmpty());
+    }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/entities/data/DataEntityTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/entities/data/DataEntityTest.java
@@ -12,12 +12,17 @@ import java.net.URL;
 import edu.kit.datamanager.ro_crate.HelpFunctions;
 import edu.kit.datamanager.ro_crate.entities.data.DataEntity.DataEntityBuilder;
 import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
+import java.net.MalformedURLException;
 
+import java.net.URISyntaxException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Nikola Tzotchev on 4.2.2022 г.
@@ -25,125 +30,142 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  */
 public class DataEntityTest {
 
-  @Test
-  void testSerialization() throws IOException {
-    ObjectMapper objectMapper = MyObjectMapper.getMapper();
+    @Test
+    void testSerialization() throws IOException {
+        ObjectMapper objectMapper = MyObjectMapper.getMapper();
 
-    ObjectNode bigJson = objectMapper.createObjectNode();
-    bigJson.put("onefield", "dalkfa");
-    ObjectNode address = objectMapper.createObjectNode();
-    address.put("street", "x");
-    address.put("city", "other");
-    address.put("state", "this");
-    address.put("zipCode", 66439);
-    bigJson.set("nestedObject", address);
+        ObjectNode bigJson = objectMapper.createObjectNode();
+        bigJson.put("onefield", "dalkfa");
+        ObjectNode address = objectMapper.createObjectNode();
+        address.put("street", "x");
+        address.put("city", "other");
+        address.put("state", "this");
+        address.put("zipCode", 66439);
+        bigJson.set("nestedObject", address);
 
-    DataEntity file = new DataEntityBuilder()
-        .addType("File")
-        .setId("https://zenodo.org/record/3541888/files/ro-crate-1.0.0.pdf")
-        .addProperty("name", "RO-Crate specification")
-        .addProperty("encodingFormat", "application/pdf")
-        .addProperty("url", "https://zenodo.org/record/3541888")
-        // this should not be included since it does not follow the json flatten form of the RO-Crate
-        .addProperty("test", bigJson)
-        .build();
-    assertNull(file.getProperty("test"));
-    HelpFunctions.compareEntityWithFile(file, "/json/entities/data/fileEntity.json");
-  }
+        DataEntity file = new DataEntityBuilder()
+                .addType("File")
+                .setId("https://zenodo.org/record/3541888/files/ro-crate-1.0.0.pdf")
+                .addProperty("name", "RO-Crate specification")
+                .addProperty("encodingFormat", "application/pdf")
+                .addProperty("url", "https://zenodo.org/record/3541888")
+                // this should not be included since it does not follow the json flatten form of the RO-Crate
+                .addProperty("test", bigJson)
+                .build();
+        assertNull(file.getProperty("test"));
+        HelpFunctions.compareEntityWithFile(file, "/json/entities/data/fileEntity.json");
+    }
 
-  @Test
-  void testSerializationOutside() throws IOException {
-    ObjectMapper objectMapper = MyObjectMapper.getMapper();
-    ObjectNode json = objectMapper.createObjectNode();
-    json.put("name", "RO-Crate specification");
-    json.put("encodingFormat", "application/pdf");
-    json.put("url", "https://zenodo.org/record/3541888");
-    json.put("@id", "https://zenodo.org/record/3541888/files/ro-crate-1.0.0.pdf");
-    json.put("@type", "File");
+    @Test
+    void testSerializationOutside() throws IOException {
+        ObjectMapper objectMapper = MyObjectMapper.getMapper();
+        ObjectNode json = objectMapper.createObjectNode();
+        json.put("name", "RO-Crate specification");
+        json.put("encodingFormat", "application/pdf");
+        json.put("url", "https://zenodo.org/record/3541888");
+        json.put("@id", "https://zenodo.org/record/3541888/files/ro-crate-1.0.0.pdf");
+        json.put("@type", "File");
 
-    DataEntity data = new DataEntity.DataEntityBuilder().build();
-    data.setProperties(json);
-    HelpFunctions.compareEntityWithFile(data, "/json/entities/data/fileEntity.json");
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            DataEntity data = new DataEntity.DataEntityBuilder().build();
+            data.setProperties(json);
+            HelpFunctions.compareEntityWithFile(data, "/json/entities/data/fileEntity.json");
 
-    ObjectNode address = objectMapper.createObjectNode();
-    address.put("street", "x");
-    address.put("city", "other");
-    address.put("state", "this");
-    address.put("zipCode", 66439);
-    json.set("nestedObject", address);
-    // this should not be included into the entity since it does not follow the basic RO-Crate structure
-    data.setProperties(json);
-    assertNotEquals("", data.getId());
-    HelpFunctions.compareEntityWithFile(data, "/json/entities/data/fileEntity.json");
-  }
+            ObjectNode address = objectMapper.createObjectNode();
+            address.put("street", "x");
+            address.put("city", "other");
+            address.put("state", "this");
+            address.put("zipCode", 66439);
+            json.set("nestedObject", address);
+            // this should not be included into the entity since it does not follow the basic RO-Crate structure
+            data.setProperties(json);
+            assertNotEquals("", data.getId());
+            HelpFunctions.compareEntityWithFile(data, "/json/entities/data/fileEntity.json");
 
-  @Test
-  void testUrlCheck() {
-    // get the std output redirected, so we can see if there is something written
-    PrintStream standardOut = System.out;
-    ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(outputStreamCaptor));
+        });
+        assertEquals("This Data Entity remote ID does not resolve to a valid URL.", exception.getMessage());
 
-    // create data entity with random ID that is not a remote URI
-    // this should create a warning in the console
-    new DataEntity.DataEntityBuilder()
-        .addType("File")
-        .setId("dfkjdfkj")
-        .build();
+    }
 
-    assertEquals("This Data Entity remote ID does not resolve to a valid URL.", outputStreamCaptor.toString().trim());
-    // also clear the stream so that we get it ready for the next comparison
-    outputStreamCaptor.reset();
+    @Test
+    void testUrlCheck() {
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            // create data entity with random ID that is not a remote URI
+        // this should create a warning in the console
+        new DataEntity.DataEntityBuilder()
+                .addType("File")
+                .setId("dfkjdfkj")
+                .build();
 
-    // this entity id is a valid URL so there should not be any console information
-    new DataEntity.DataEntityBuilder()
-        .addType("File")
-        .setId("https://www.example.com/19")
-        .build();
+        });
 
+        assertEquals("This Data Entity remote ID does not resolve to a valid URL.", exception.getMessage());
 
-    assertEquals("", outputStreamCaptor.toString().trim());
-    URL url =
-        HelpFunctions.class.getResource("/json/crate/simple2.json");
-    assert url != null;
+        //this entity id is a valid URL so there should not be any console information
+        DataEntity dataEntity = new DataEntity.DataEntityBuilder()
+                .addType("File")
+                .setId("https://www.example.com/19")
+                .build();
 
-    // this data entity is not a remote one, so there should not be any messages
-    new DataEntity.DataEntityBuilder()
-        .addType("File")
-        .setSource(new File(url.getFile()))
-        .build();
+        assertNotNull(dataEntity);
+        
+        exception = assertThrows(IllegalArgumentException.class, () -> {
+        new DataEntity.DataEntityBuilder()
+                    .addType("File")
+                    .setSource(new File("/json/crate/results and diagrams.json"))
+                    .build();
 
-    outputStreamCaptor.reset();
-    assertEquals("", outputStreamCaptor.toString().trim());
-    System.setOut(standardOut);
-  }
-  @Test
-  void testEncodedUrl() {
-    // get the std output redirected, so we can see if there is something written
-    PrintStream standardOut = System.out;
-    ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(outputStreamCaptor));
+        });
 
-    // this entity id is a valid URL so there should not be any console information
-    new DataEntity.DataEntityBuilder()
-            .addType("File")
-            .setId("https%3A%2F%2Fgithub.com%2Fkit-data-manager%2Fro-crate-java%2Fissues%2F5")
-            .build();
+        assertEquals("The ID is not correctly encoded.", exception.getMessage());
+    }
 
+    @Test
+    void testEncodedUrl() throws MalformedURLException, URISyntaxException {
+        //this entity id is a valid URL so there should not be any console information
+        DataEntity dataEntity = new DataEntity.DataEntityBuilder()
+                .addType("File")
+                .setId("https://github.com/kit-data-manager/ro-crate-java/issues/5")
+                .build();
 
-    assertEquals("", outputStreamCaptor.toString().trim());
-    URL url =
-            HelpFunctions.class.getResource("/json/crate/simple2.json");
-    assert url != null;
+        assertEquals("https://github.com/kit-data-manager/ro-crate-java/issues/5", dataEntity.getId());
 
-    // this data entity is not a remote one, so there should not be any messages
-    new DataEntity.DataEntityBuilder()
-            .addType("File")
-            .setSource(new File(url.getFile()))
-            .build();
+        URL url
+                = HelpFunctions.class.getResource("/json/crate/simple2.json");
+        assert url != null;
+        // this data entity is not a remote one, so there should not be any messages
+        dataEntity = new DataEntity.DataEntityBuilder()
+                .addType("File")
+                .setSource(new File(url.getFile()))
+                .build();
 
-    assertEquals("", outputStreamCaptor.toString().trim());
+        assertNotNull(dataEntity);
 
-    System.setOut(standardOut);
-  }
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            new DataEntity.DataEntityBuilder()
+                    .addType("File")
+                    .setId("/json/crate/Results%20and%20Diagrams/almost-50%25.json")
+                    .build();
+
+        });
+
+        assertEquals("This Data Entity remote ID does not resolve to a valid URL.", exception.getMessage());
+
+        dataEntity = new DataEntity.DataEntityBuilder()
+                .addType("File")
+                .setSource(new File("/json/crate/Results%20and%20Diagrams/almost-50%25.json"))
+                .build();
+
+        assertTrue(dataEntity.getTypes().contains("File"));
+
+        exception = assertThrows(IllegalArgumentException.class, () -> {
+            new DataEntity.DataEntityBuilder()
+                    .addType("File")
+                    .setSource(new File("/json/crate/Results and Diagrams/almost-50%.json"))
+                    .build();
+
+        });
+
+        assertEquals("The ID is not correctly encoded.", exception.getMessage());
+    }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/special/UriUtilTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/special/UriUtilTest.java
@@ -1,0 +1,64 @@
+package edu.kit.datamanager.ro_crate.special;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+public class UriUtilTest {
+
+    // Strings taken from
+    // https://www.researchobject.org/ro-crate/1.1/data-entities.html#encoding-file-paths
+    private static String file_chinese = "面试.mp4";
+    private static String file_chinese_encoded = "%E9%9D%A2%E8%AF%95.mp4";
+    private static String file_path_spaces = "Results and Diagrams\\almost-50%.png";
+    // note: "\" becomes "/" (unix style):
+    private static String file_path_spaces_encoded = "Results%20and%20Diagrams/almost-50%25.png";
+
+    @Test
+    void testIsEncodedWithRoCrateSpecExamples() {
+        assertTrue(UriUtil.isEncoded(file_chinese));
+        assertTrue(UriUtil.isEncoded(file_chinese_encoded));
+        assertFalse(UriUtil.isEncoded(file_path_spaces));
+        assertTrue(UriUtil.isEncoded(file_path_spaces_encoded));
+    }
+
+    @Test
+    void testIsUrlWithRoCrateSpecExamples() {
+        assertFalse(UriUtil.isUrl(file_chinese));
+        assertFalse(UriUtil.isUrl(file_chinese_encoded));
+        assertFalse(UriUtil.isUrl(file_path_spaces));
+        assertFalse(UriUtil.isUrl(file_path_spaces_encoded));
+    }
+
+    @Test
+    void testIsPathWithRoCrateSpecExamples() {
+        assertTrue(UriUtil.isPath(file_chinese));
+        assertTrue(UriUtil.isPath(file_chinese_encoded));
+        assertTrue(UriUtil.isPath(file_path_spaces));
+        assertTrue(UriUtil.isPath(file_path_spaces_encoded));
+
+    }
+    
+    @Test
+    void testIsPathWithUrlExamples() {
+        assertFalse(UriUtil.isPath("https://example.com/"));
+        assertFalse(UriUtil.isPath("https://example.com/file.html"));
+        assertFalse(UriUtil.isPath("http://example-doesnotexist.com"));
+    }
+
+    @Test
+    void testUriEncodingFileChinese() {
+        Optional<String> encoded = UriUtil.encode(file_chinese);
+        assertEquals(file_chinese, encoded.get());
+    }
+
+    @Test
+    void testUriEncodingFilePathSpaces() {
+        Optional<String> encoded = UriUtil.encode(file_path_spaces);
+        assertEquals(file_path_spaces_encoded, encoded.get());
+    }
+}

--- a/src/test/java/edu/kit/datamanager/ro_crate/special/UriUtilTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/special/UriUtilTest.java
@@ -59,10 +59,10 @@ public class UriUtilTest {
      */
     @Test
     void testIsEncodedWithRoCrateSpecExamples() {
-        assertTrue(UriUtil.isEncoded(file_chinese));
-        assertTrue(UriUtil.isEncoded(file_chinese_encoded));
-        assertFalse(UriUtil.isEncoded(file_path_spaces));
-        assertTrue(UriUtil.isEncoded(file_path_spaces_encoded));
+        assertTrue(UriUtil.isValidUri(file_chinese));
+        assertTrue(UriUtil.isValidUri(file_chinese_encoded));
+        assertFalse(UriUtil.isValidUri(file_path_spaces));
+        assertTrue(UriUtil.isValidUri(file_path_spaces_encoded));
     }
 
     /**
@@ -70,10 +70,10 @@ public class UriUtilTest {
      */
     @Test
     void testIsDecodedWithRoCrateSpecExamples() {
-        assertFalse(UriUtil.isDecoded(file_chinese));
-        assertFalse(UriUtil.isDecoded(file_chinese_encoded));
-        assertTrue(UriUtil.isDecoded(file_path_spaces));
-        assertFalse(UriUtil.isDecoded(file_path_spaces_encoded));
+        assertFalse(UriUtil.isNotValidUri(file_chinese));
+        assertFalse(UriUtil.isNotValidUri(file_chinese_encoded));
+        assertTrue(UriUtil.isNotValidUri(file_path_spaces));
+        assertFalse(UriUtil.isNotValidUri(file_path_spaces_encoded));
     }
 
     /**
@@ -146,7 +146,7 @@ public class UriUtilTest {
     void testEncode(String example_unencoded, String example_encoded) {
         Optional<String> encoded = UriUtil.encode(example_unencoded);
         assertEquals(example_encoded, encoded.get());
-        assertTrue(UriUtil.isEncoded(encoded.get()));
+        assertTrue(UriUtil.isValidUri(encoded.get()));
     }
 
     /**
@@ -159,6 +159,5 @@ public class UriUtilTest {
     void testDecode(String example_unencoded, String example_encoded) {
         Optional<String> decoded = UriUtil.decode(example_encoded);
         assertEquals(example_unencoded, decoded.get());
-        assertTrue(UriUtil.isDecoded(decoded.get()));
     }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/special/UriUtilTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/special/UriUtilTest.java
@@ -5,36 +5,58 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class UriUtilTest {
 
     // Strings taken from
     // https://www.researchobject.org/ro-crate/1.1/data-entities.html#encoding-file-paths
-    private static final String file_chinese = "面试.mp4";
-    private static final String file_chinese_encoded = "%E9%9D%A2%E8%AF%95.mp4";
-    private static final String file_path_spaces = "Results and Diagrams\\almost-50%.png";
+    static final String file_chinese = "面试.mp4";
+    static final String file_chinese_encoded = "%E9%9D%A2%E8%AF%95.mp4";
+    static final String file_path_spaces = "Results and Diagrams\\almost-50%.png";
     // note: "\" becomes "/" (unix style):
-    private static String file_path_spaces_encoded = "Results%20and%20Diagrams/almost-50%25.png";
+    static final String file_path_spaces_encoded = "Results%20and%20Diagrams/almost-50%25.png";
 
     // taken from
     // https://www.researchobject.org/ro-crate/1.1/appendix/jsonld.html#describing-entities-in-json-ld
-    private static final String url_simple_valid = "http://example.com/";
-    private static final String url_orcid_valid = "https://orcid.org/0000-0002-1825-0097";
-    private static final String entity_reference_simple = "#alice";
-    private static final String entity_reference_generated = "#ac0bd781-7d91-4cdf-b2ad-7305921c7650";
-    private static final String entity_blank_node_id = "_:alice";
+    static final String url_simple_valid = "http://example.com/";
+    static final String url_orcid_valid = "https://orcid.org/0000-0002-1825-0097";
+    static final String entity_reference_simple = "#alice";
+    static final String entity_reference_generated = "#ac0bd781-7d91-4cdf-b2ad-7305921c7650";
+    static final String entity_blank_node_id = "_:alice";
 
+    // Other tests
+    static final String url_with_spaces = "https://example.com/file with spaces";
+    static final String url_with_spaces_encoded = "https://example.com/file%20with%20spaces";
 
-    void assertEncodingIsTheSame(String uri) {
-        // The uri should not be changed when encoding (no double encoding)
-        Optional<String> encoded = UriUtil.encode(uri);
-        assertEquals(uri, encoded.get());
-        // The uri should be recognized as encoded
-        assertTrue(UriUtil.isEncoded(uri));
+    public static Stream<Arguments> encodingExamplesProvider() {
+        return Stream.of(
+                // before encoding , after encoding
+                Arguments.of(file_path_spaces, file_path_spaces_encoded),
+                Arguments.of(url_with_spaces, url_with_spaces_encoded),
+                // double encoding does not happen
+                Arguments.of(file_chinese_encoded, file_chinese_encoded),
+                Arguments.of(file_path_spaces_encoded, file_path_spaces_encoded),
+                Arguments.of(url_with_spaces_encoded, url_with_spaces_encoded),
+                // some things should stay as they are according to the specification
+                Arguments.of(file_chinese, file_chinese),
+                Arguments.of(url_simple_valid, url_simple_valid),
+                Arguments.of(url_orcid_valid, url_orcid_valid),
+                Arguments.of(entity_reference_simple, entity_reference_simple),
+                Arguments.of(entity_reference_generated, entity_reference_generated),
+                Arguments.of(entity_blank_node_id, entity_blank_node_id)
+        );
     }
 
+    /**
+     * Encoding works with the examples from the specification.
+     */
     @Test
     void testIsEncodedWithRoCrateSpecExamples() {
         assertTrue(UriUtil.isEncoded(file_chinese));
@@ -43,6 +65,9 @@ public class UriUtilTest {
         assertTrue(UriUtil.isEncoded(file_path_spaces_encoded));
     }
 
+    /**
+     * Decoding works with the examples from the specification.
+     */
     @Test
     void testIsDecodedWithRoCrateSpecExamples() {
         assertFalse(UriUtil.isDecoded(file_chinese));
@@ -51,6 +76,9 @@ public class UriUtilTest {
         assertFalse(UriUtil.isDecoded(file_path_spaces_encoded));
     }
 
+    /**
+     * Detecting URLs works with the examples from the specification.
+     */
     @Test
     void testIsUrlWithRoCrateSpecExamples() {
         assertFalse(UriUtil.isUrl(file_chinese));
@@ -59,6 +87,9 @@ public class UriUtilTest {
         assertFalse(UriUtil.isUrl(file_path_spaces_encoded));
     }
 
+    /**
+     * Detecting paths works with the examples from the specification.
+     */
     @Test
     void testIsPathWithRoCrateSpecExamples() {
         assertTrue(UriUtil.isPath(file_chinese));
@@ -68,46 +99,66 @@ public class UriUtilTest {
 
     }
 
-    @Test
-    void testIsPathWithUrlExamples() {
-        assertFalse(UriUtil.isPath("https://example.com/"));
-        assertFalse(UriUtil.isPath("https://example.com/file.html"));
-        assertFalse(UriUtil.isPath("http://example-doesnotexist.com"));
+    /**
+     * Detecting and differentiating given URLs from paths works.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            url_simple_valid,
+            url_orcid_valid,
+            url_with_spaces,
+            url_with_spaces_encoded,
+            "https://example.com/file.html",
+            "http://example-doesnotexist.com",
+    })
+    void testIsPathAndisUrlWithUrls(String url) {
+        assertFalse(UriUtil.isPath(url));
+        assertTrue(UriUtil.isUrl(url));
     }
 
-    @Test
-    void testEncodePreferReadableAboutFullEncoding() {
-        assertEncodingIsTheSame(file_chinese);
+    /**
+     * Detecting and differentiating given paths from URLs works.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            file_chinese,
+            file_chinese_encoded,
+            file_path_spaces,
+            file_path_spaces_encoded,
+            "./file.html",
+            "file.html",
+    })
+    void testIsPathAndisUrlWithPaths(String path) {
+        assertTrue(UriUtil.isPath(path));
+        assertFalse(UriUtil.isUrl(path));
     }
 
-    @Test
-    void testEncodeFilePathSpaces() {
-        Optional<String> encoded = UriUtil.encode(file_path_spaces);
-        assertEquals(file_path_spaces_encoded, encoded.get());
+    /**
+     * Tests the encoding function for several "before-after" pairs.
+     * 
+     * This includes normal tests,
+     * checks that double-encoding does not happen,
+     * and makes sure that some examples and exceptions of the specification are
+     * handled correctly.
+     */
+    @ParameterizedTest(name = "testEncodeWith {0} and {1}")
+    @MethodSource("edu.kit.datamanager.ro_crate.special.UriUtilTest#encodingExamplesProvider")
+    void testEncode(String example_unencoded, String example_encoded) {
+        Optional<String> encoded = UriUtil.encode(example_unencoded);
+        assertEquals(example_encoded, encoded.get());
+        assertTrue(UriUtil.isEncoded(encoded.get()));
     }
 
-    @Test
-    void testEncodeSimpleEntityReference() {
-        assertEncodingIsTheSame(entity_reference_simple);
-    }
-
-    @Test
-    void testEncodeGeneratedEntityReference() {
-        assertEncodingIsTheSame(entity_reference_generated);
-    }
-
-    @Test
-    void testEncodeBlankNodeReference() {
-        assertEncodingIsTheSame(entity_blank_node_id);
-    }
-
-    @Test
-    void testEncodeUrlSimple() {
-        assertEncodingIsTheSame(url_simple_valid);
-    }
-
-    @Test
-    void testEncodeUrlOrcid() {
-        assertEncodingIsTheSame(url_orcid_valid);
+    /**
+     * Same as testEncode, but with the decode function.
+     * 
+     * Uses the same input examples, but in the reverse direction.
+     */
+    @ParameterizedTest(name = "testDecodeWith {0} and {1}")
+    @MethodSource("edu.kit.datamanager.ro_crate.special.UriUtilTest#encodingExamplesProvider")
+    void testDecode(String example_unencoded, String example_encoded) {
+        Optional<String> decoded = UriUtil.decode(example_encoded);
+        assertEquals(example_unencoded, decoded.get());
+        assertTrue(UriUtil.isDecoded(decoded.get()));
     }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/special/UriUtilTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/special/UriUtilTest.java
@@ -12,9 +12,9 @@ public class UriUtilTest {
 
     // Strings taken from
     // https://www.researchobject.org/ro-crate/1.1/data-entities.html#encoding-file-paths
-    private static String file_chinese = "面试.mp4";
-    private static String file_chinese_encoded = "%E9%9D%A2%E8%AF%95.mp4";
-    private static String file_path_spaces = "Results and Diagrams\\almost-50%.png";
+    private static final String file_chinese = "面试.mp4";
+    private static final String file_chinese_encoded = "%E9%9D%A2%E8%AF%95.mp4";
+    private static final String file_path_spaces = "Results and Diagrams\\almost-50%.png";
     // note: "\" becomes "/" (unix style):
     private static String file_path_spaces_encoded = "Results%20and%20Diagrams/almost-50%25.png";
 
@@ -42,7 +42,7 @@ public class UriUtilTest {
         assertTrue(UriUtil.isPath(file_path_spaces_encoded));
 
     }
-    
+
     @Test
     void testIsPathWithUrlExamples() {
         assertFalse(UriUtil.isPath("https://example.com/"));
@@ -51,13 +51,12 @@ public class UriUtilTest {
     }
 
     @Test
-    void testUriEncodingFileChinese() {
-        Optional<String> encoded = UriUtil.encode(file_chinese);
-        assertEquals(file_chinese, encoded.get());
+    void testEncodePreferReadableAboutFullEncoding() {
+        assertEncodingIsTheSame(file_chinese);
     }
 
     @Test
-    void testUriEncodingFilePathSpaces() {
+    void testEncodeFilePathSpaces() {
         Optional<String> encoded = UriUtil.encode(file_path_spaces);
         assertEquals(file_path_spaces_encoded, encoded.get());
     }

--- a/src/test/java/edu/kit/datamanager/ro_crate/special/UriUtilTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/special/UriUtilTest.java
@@ -18,12 +18,37 @@ public class UriUtilTest {
     // note: "\" becomes "/" (unix style):
     private static String file_path_spaces_encoded = "Results%20and%20Diagrams/almost-50%25.png";
 
+    // taken from
+    // https://www.researchobject.org/ro-crate/1.1/appendix/jsonld.html#describing-entities-in-json-ld
+    private static final String url_simple_valid = "http://example.com/";
+    private static final String url_orcid_valid = "https://orcid.org/0000-0002-1825-0097";
+    private static final String entity_reference_simple = "#alice";
+    private static final String entity_reference_generated = "#ac0bd781-7d91-4cdf-b2ad-7305921c7650";
+    private static final String entity_blank_node_id = "_:alice";
+
+
+    void assertEncodingIsTheSame(String uri) {
+        // The uri should not be changed when encoding (no double encoding)
+        Optional<String> encoded = UriUtil.encode(uri);
+        assertEquals(uri, encoded.get());
+        // The uri should be recognized as encoded
+        assertTrue(UriUtil.isEncoded(uri));
+    }
+
     @Test
     void testIsEncodedWithRoCrateSpecExamples() {
         assertTrue(UriUtil.isEncoded(file_chinese));
         assertTrue(UriUtil.isEncoded(file_chinese_encoded));
         assertFalse(UriUtil.isEncoded(file_path_spaces));
         assertTrue(UriUtil.isEncoded(file_path_spaces_encoded));
+    }
+
+    @Test
+    void testIsDecodedWithRoCrateSpecExamples() {
+        assertFalse(UriUtil.isDecoded(file_chinese));
+        assertFalse(UriUtil.isDecoded(file_chinese_encoded));
+        assertTrue(UriUtil.isDecoded(file_path_spaces));
+        assertFalse(UriUtil.isDecoded(file_path_spaces_encoded));
     }
 
     @Test
@@ -59,5 +84,30 @@ public class UriUtilTest {
     void testEncodeFilePathSpaces() {
         Optional<String> encoded = UriUtil.encode(file_path_spaces);
         assertEquals(file_path_spaces_encoded, encoded.get());
+    }
+
+    @Test
+    void testEncodeSimpleEntityReference() {
+        assertEncodingIsTheSame(entity_reference_simple);
+    }
+
+    @Test
+    void testEncodeGeneratedEntityReference() {
+        assertEncodingIsTheSame(entity_reference_generated);
+    }
+
+    @Test
+    void testEncodeBlankNodeReference() {
+        assertEncodingIsTheSame(entity_blank_node_id);
+    }
+
+    @Test
+    void testEncodeUrlSimple() {
+        assertEncodingIsTheSame(url_simple_valid);
+    }
+
+    @Test
+    void testEncodeUrlOrcid() {
+        assertEncodingIsTheSame(url_orcid_valid);
     }
 }


### PR DESCRIPTION
Fixes #5. I started by adding a utility class to explore the possibilities to encode things and detect encoding using different solutions.

- I figured that `UrlValidator.isValid()` is not a good solution as it
  1. requires the domain to (still) exist, which might be helpful for warnings, but may cause crates to break over time.
  2. requires an internet connection to do so
  3. therefore, does not always have the semantic of "this is not a URL", but sometimes just "this domain does not exist (anymore)".
- There are Java data structures which do this implicitly.

Status

- [x] add isUrl, isPath, asUrl, asPath, and basic tests for them
- [x] add a first prototype of an encoding which considers the not too consistent hint in the specs: https://www.researchobject.org/ro-crate/1.1/data-entities.html#encoding-file-paths
- [x] (uses the junit dependencies now as in the official documentation, as it confused vscodes java language server at some point)
- [ ] add decoding functionality
- [x] test that decoding reverses encoding properly
- [x] test that we do only encode/decode if required (the functions otherwise do not change the string)
- [ ] more negative tests
- [ ] Apply the functions to the current places where we decode, see #5 
- [ ] Apply the functions to the places where we need to encode (currently we do not do this)