### PR TITLE
Fix #105: "multiple conformsTo values"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,22 @@
 [![Publish to Maven Central / OSSRH](https://github.com/kit-data-manager/ro-crate-java/actions/workflows/publishRelease.yml/badge.svg)](https://github.com/kit-data-manager/ro-crate-java/actions/workflows/publishRelease.yml)
 
 A Java library to create and modify RO-Crates.
-Read [Quickstart](#quickstart) for a short overview of the API
+The aim of this implementation is to **not** require too deep knowledge of the specification,
+and avoiding crates which do not fully comply to the specification, at the same time.
+Read [Quick-start](#quick-start) for a short overview of the API
 or take a look at [how to adapt the examples from the official specification](#adapting-the-specification-examples).
 
 Build and run tests: `./gradlew build`  
 Build documentation: `./gradlew javadoc`
 
 On Windows, replace `./gradlew` with `gradlew.bat`.
+
+## RO-Crate Specification Compatibility
+
+- ✅ Version 1.1
+- 🛠️ Version 1.2-DRAFT
+  - ✅ Reading and writing crates with additional profiles or specifications ([examples for reading](src/test/java/edu/kit/datamanager/ro_crate/reader/RoCrateReaderSpec12Test.java), [examples for writing](src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateWriterSpec12Test.java))
+  - ✅ Adding profiles or other specifications to a crate ([examples](src/test/java/edu/kit/datamanager/ro_crate/crate/BuilderSpec12Test.java))
 
 ## Quick-start
 ### Example for a basic crate from [RO-Crate website](https://www.researchobject.org/ro-crate/1.1/root-data-entity.html#ro-crate-metadata-file-descriptor)

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,10 @@ plugins {
 group 'edu.kit.datamanager'
 description = "A library for easy creation and modification of valid RO-Crates."
 
+println "Running gradle version: $gradle.gradleVersion"
+println "Building ${name} version: ${version}"
+println "JDK version: ${JavaVersion.current()}"
+
 repositories {
     mavenCentral()
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/Crate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/Crate.java
@@ -3,6 +3,7 @@ package edu.kit.datamanager.ro_crate;
 import java.io.File;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import edu.kit.datamanager.ro_crate.context.CrateMetadataContext;
 import edu.kit.datamanager.ro_crate.entities.AbstractEntity;
@@ -10,6 +11,7 @@ import edu.kit.datamanager.ro_crate.entities.contextual.ContextualEntity;
 import edu.kit.datamanager.ro_crate.entities.data.DataEntity;
 import edu.kit.datamanager.ro_crate.entities.data.RootDataEntity;
 import edu.kit.datamanager.ro_crate.preview.CratePreview;
+import edu.kit.datamanager.ro_crate.special.CrateVersion;
 
 /**
  * An interface describing an ROCrate.
@@ -18,6 +20,33 @@ import edu.kit.datamanager.ro_crate.preview.CratePreview;
  * @version 1
  */
 public interface Crate {
+
+  /**
+   * Read version from the crate descriptor and return it as a class
+   * representation.
+   * 
+   * NOTE: If there is not version in the crate, it does not comply with the
+   * specification.
+   * 
+   * @return the class representation indication the version of this crate, if
+   *         available.
+   */
+  public Optional<CrateVersion> getVersion();
+
+  /**
+   * Returns strings indicating the conformance of a crate with other
+   * specifications than the RO-Crate version.
+   * 
+   * If you need the crate version too, refer to {@link #getVersion()}.
+   * 
+   * This corresponds technically to all conformsTo values, excluding the RO crate
+   * version / specification.
+   * 
+   * @return a collection of the profiles or specifications this crate conforms
+   *         to.
+   */
+  public Collection<String> getProfiles();
+
   CratePreview getPreview();
 
   void setMetadataContext(CrateMetadataContext metadataContext);

--- a/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
@@ -354,7 +354,7 @@ public class RoCrate implements Crate {
     }
 
     /**
-     * @return a crate with the information from this builder.
+     * Returns a crate with the information from this builder.
      */
     public RoCrate build() {
       return new RoCrate(this);

--- a/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
@@ -32,9 +32,12 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-
 /**
  * The class that represents a single ROCrate.
+ * 
+ * To build or modify it, use a instance of {@link RoCrateBuilder}. In the case
+ * features of RO-Crate DRAFT specifications are needed, refer to
+ * {@link BuilderWithDraftFeatures} and its documentation.
  *
  * @author Nikola Tzotchev on 6.2.2022 г.
  * @version 1
@@ -351,6 +354,9 @@ public class RoCrate implements Crate {
       return this;
     }
 
+    /**
+     * @return a crate with the information from this builder.
+     */
     public RoCrate build() {
       return new RoCrate(this);
     }
@@ -374,7 +380,6 @@ public class RoCrate implements Crate {
     JsonDescriptor.Builder descriptorBuilder = new JsonDescriptor.Builder();
 
     /**
-     * {@inheritDoc}
      * @see RoCrateBuilder#RoCrateBuilder()
      */
     public BuilderWithDraftFeatures() {
@@ -382,17 +387,14 @@ public class RoCrate implements Crate {
     }
 
     /**
-     * {@inheritDoc}
-     * @param name {@inheritDoc}
-     * @param description {@inheritDoc}
+     * @see RoCrateBuilder#RoCrateBuilder(String, String)
      */
     public BuilderWithDraftFeatures(String name, String description) {
       super();
     }
 
     /**
-     * {@inheritDoc}
-     * @param crate {@inheritDoc}
+     * @see RoCrateBuilder#RoCrateBuilder(RoCrate)
      */
     public BuilderWithDraftFeatures(RoCrate crate) {
       super(crate);

--- a/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
@@ -104,7 +104,7 @@ public class RoCrate implements Crate {
     this.metadataContext = roCrateBuilder.metadataContext;
     this.roCratePreview = roCrateBuilder.preview;
     this.rootDataEntity = roCrateBuilder.rootDataEntity;
-    this.jsonDescriptor = roCrateBuilder.jsonDescriptor;
+    this.jsonDescriptor = roCrateBuilder.descriptorBuilder.build();
     this.untrackedFiles = roCrateBuilder.untrackedFiles;
     Validator defaultValidation = new Validator(new JsonSchemaValidation());
     defaultValidation.validate(this);
@@ -252,8 +252,9 @@ public class RoCrate implements Crate {
     CrateMetadataContext metadataContext;
     ContextualEntity license;
     RootDataEntity rootDataEntity;
-    ContextualEntity jsonDescriptor;
     List<File> untrackedFiles;
+
+    JsonDescriptor.Builder descriptorBuilder = new JsonDescriptor.Builder();
 
     /**
      * The default constructor of a builder.
@@ -269,7 +270,6 @@ public class RoCrate implements Crate {
           .addProperty("name", name)
           .addProperty("description", description)
           .build();
-      jsonDescriptor = new JsonDescriptor();
     }
 
     /**
@@ -282,7 +282,6 @@ public class RoCrate implements Crate {
       this.metadataContext = new RoCrateMetadataContext();
       rootDataEntity = new RootDataEntity.RootDataEntityBuilder()
           .build();
-      jsonDescriptor = new JsonDescriptor();
     }
 
     /**
@@ -295,8 +294,8 @@ public class RoCrate implements Crate {
       this.preview = crate.roCratePreview;
       this.metadataContext = crate.metadataContext;
       this.rootDataEntity = crate.rootDataEntity;
-      this.jsonDescriptor = crate.jsonDescriptor;
       this.untrackedFiles = crate.untrackedFiles;
+      this.descriptorBuilder = new JsonDescriptor.Builder(crate);
     }
 
     /**
@@ -377,8 +376,6 @@ public class RoCrate implements Crate {
    */
   public static class BuilderWithDraftFeatures extends RoCrateBuilder {
 
-    JsonDescriptor.Builder descriptorBuilder = new JsonDescriptor.Builder();
-
     /**
      * @see RoCrateBuilder#RoCrateBuilder()
      */
@@ -417,12 +414,6 @@ public class RoCrate implements Crate {
           // usage of a draft feature results in draft version numbers of the crate
           .setVersion(CrateVersion.LATEST_UNSTABLE);
       return this;
-    }
-
-    @Override
-    public RoCrate build() {
-      this.jsonDescriptor = this.descriptorBuilder.build();
-      return new RoCrate(this);
     }
   }
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
@@ -306,13 +306,12 @@ public class AbstractEntity {
     }
 
     /**
-     * Setting the id property of the entity.
+     * Setting the id property of the entity, if the given value is not null.
      *
      * @param id the String representing the id.
      * @return the generic builder.
      */
     public T setId(String id) {
-      // TODO document why this has been implemented this way.
       if (id != null) {
         this.id = id;
       }

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/JsonDescriptor.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/JsonDescriptor.java
@@ -1,0 +1,85 @@
+package edu.kit.datamanager.ro_crate.entities.contextual;
+
+import java.net.URI;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
+import edu.kit.datamanager.ro_crate.special.CrateVersion;
+
+public class JsonDescriptor extends ContextualEntity {
+
+    private static final String CONFORMS_TO = "conformsTo";
+    protected static final String ID = "ro-crate-metadata.json";
+
+    /**
+     * Returns a JsonDescriptor with the conformsTo value set to the latest stable
+     * version.
+     */
+    public JsonDescriptor() {
+        super(
+                staticPropertiesPrefilledBuilder()
+                        .addIdProperty(CONFORMS_TO, CrateVersion.LATEST_STABLE.conformsTo));
+    }
+
+    protected static ContextualEntityBuilder staticPropertiesPrefilledBuilder() {
+        return new ContextualEntity.ContextualEntityBuilder()
+                .setId(ID)
+                .addType("CreativeWork")
+                .addIdProperty("about", "./");
+    }
+
+    private JsonDescriptor(ContextualEntityBuilder builder) {
+        super(builder);
+    }
+
+    /**
+     * Builder for the JsonDescriptor.
+     * 
+     * Defaults to the latest stable crate version and no other conformsTo values.
+     */
+    public static final class Builder {
+        CrateVersion version = CrateVersion.LATEST_STABLE;
+        Set<String> otherConformsToValues = new HashSet<>();
+
+        public Builder setVersion(CrateVersion version) {
+            this.version = version;
+            return this;
+        }
+
+        public Builder addConformsTo(String uri) {
+            this.otherConformsToValues.add(uri);
+            return this;
+        }
+
+        public Builder addConformsTo(URI uri) {
+            this.otherConformsToValues.add(uri.toString());
+            return this;
+        }
+
+        public JsonDescriptor build() {
+            if (this.otherConformsToValues.isEmpty()) {
+                // in this case we do not need an array
+                ContextualEntityBuilder entityBuilder = staticPropertiesPrefilledBuilder()
+                        .addIdProperty(CONFORMS_TO, this.version.conformsTo);
+                return new JsonDescriptor(entityBuilder);
+            } else {
+                // use an array to collect all values into an array of simple @id objects.
+                ObjectMapper mapper = MyObjectMapper.getMapper();
+                ArrayNode array = mapper.createArrayNode();
+                array.add(
+                        mapper.createObjectNode().put("@id", this.version.conformsTo));
+                for (String other : this.otherConformsToValues) {
+                    array.add(
+                            mapper.createObjectNode().put("@id", other));
+                }
+                ContextualEntityBuilder entityBuilder = staticPropertiesPrefilledBuilder()
+                        .addProperty(CONFORMS_TO, array);
+                return new JsonDescriptor(entityBuilder);
+            }
+        }
+    }
+}

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/JsonDescriptor.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/JsonDescriptor.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
+import edu.kit.datamanager.ro_crate.Crate;
 import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
 import edu.kit.datamanager.ro_crate.special.CrateVersion;
 
@@ -44,6 +45,15 @@ public class JsonDescriptor extends ContextualEntity {
     public static final class Builder {
         CrateVersion version = CrateVersion.LATEST_STABLE;
         Set<String> otherConformsToValues = new HashSet<>();
+
+        public Builder() {
+            // default
+        }
+
+        public Builder(Crate crate) {
+            crate.getVersion().ifPresent(v -> this.version = v);
+            this.otherConformsToValues.addAll(crate.getProfiles());
+        }
 
         public Builder setVersion(CrateVersion version) {
             this.version = version;

--- a/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/organizationprovider/RorProvider.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/organizationprovider/RorProvider.java
@@ -41,8 +41,8 @@ public class RorProvider {
       CloseableHttpClient httpClient = HttpClients.createDefault();
       CloseableHttpResponse response = httpClient.execute(request);
     ) {
-        boolean isOk = response.getStatusLine().getStatusCode() != HttpStatus.SC_OK;
-        if (isOk) {
+        boolean isError = response.getStatusLine().getStatusCode() != HttpStatus.SC_OK;
+        if (isError) {
           String errorMessage = String.format("Identifier not found: %s", response.getStatusLine().toString());
           logger.error(errorMessage);
           return null;

--- a/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/organizationprovider/RorProvider.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/organizationprovider/RorProvider.java
@@ -6,15 +6,21 @@ import edu.kit.datamanager.ro_crate.entities.contextual.OrganizationEntity;
 import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
 
 import java.io.IOException;
+
+import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class providing possibility to import organization entities from ror.com.
  */
 public class RorProvider {
+
+  private static Logger logger = LoggerFactory.getLogger(RorProvider.class);
 
   private RorProvider() {}
 
@@ -31,10 +37,15 @@ public class RorProvider {
     String newUrl = "https://api.ror.org/organizations/" + url.replaceAll("https://ror.org/", "");
     HttpGet request = new HttpGet(newUrl);
 
-    try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
-        CloseableHttpResponse response = httpClient.execute(request);
-        if (response.getStatusLine().getStatusCode() != 200) {
-          throw new IOException(String.format("Identifier not found: %s", response.getStatusLine().toString()));
+    try (
+      CloseableHttpClient httpClient = HttpClients.createDefault();
+      CloseableHttpResponse response = httpClient.execute(request);
+    ) {
+        boolean isOk = response.getStatusLine().getStatusCode() != HttpStatus.SC_OK;
+        if (isOk) {
+          String errorMessage = String.format("Identifier not found: %s", response.getStatusLine().toString());
+          logger.error(errorMessage);
+          return null;
         }
         ObjectNode jsonNode = MyObjectMapper.getMapper().readValue(response.getEntity().getContent(),
             ObjectNode.class);
@@ -45,7 +56,8 @@ public class RorProvider {
             .addProperty("url", jsonNode.get("links"))
             .build();
     } catch (IOException e) {
-      e.printStackTrace();
+      String errorMessage = String.format("IO error: %s", e.getMessage());
+      logger.error(errorMessage);
     }
     return null;
   }

--- a/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/personprovider/OrcidProvider.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/personprovider/OrcidProvider.java
@@ -48,10 +48,11 @@ public class OrcidProvider {
       CloseableHttpClient httpClient = HttpClients.createDefault();
       CloseableHttpResponse response = httpClient.execute(request);
     ) {
-      boolean isOk = response.getStatusLine().getStatusCode() != HttpStatus.SC_OK;
-      boolean isJson = response.containsHeader(HttpHeaders.CONTENT_TYPE)
-        && response.getFirstHeader(HttpHeaders.CONTENT_TYPE).getValue().equals(ContentType.TEXT_HTML.toString());
-      if (isOk && isJson) {
+      boolean isError = response.getStatusLine().getStatusCode() != HttpStatus.SC_OK;
+      String receivedMimeType = ContentType.parse(response.getFirstHeader(HttpHeaders.CONTENT_TYPE).getValue()).getMimeType();
+      boolean isUnexpectedFormat = response.containsHeader(HttpHeaders.CONTENT_TYPE)
+        && !receivedMimeType.equals("application/ld+json");
+      if (isError || isUnexpectedFormat) {
         String errorMessage = String.format("Identifier not found: %s", response.getStatusLine().toString());
         logger.error(errorMessage);
         return null;

--- a/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/personprovider/OrcidProvider.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/personprovider/OrcidProvider.java
@@ -51,7 +51,7 @@ public class OrcidProvider {
     ) {
       boolean isOk = response.getStatusLine().getStatusCode() != HttpStatus.SC_OK;
       boolean isJson = response.containsHeader(HttpHeaders.CONTENT_TYPE)
-        && response.getFirstHeader(HttpHeaders.CONTENT_TYPE).getValue() == ContentType.TEXT_HTML.toString();
+        && response.getFirstHeader(HttpHeaders.CONTENT_TYPE).getValue().equals(ContentType.TEXT_HTML.toString());
       if (isOk && isJson) {
         String errorMessage = String.format("Identifier not found: %s", response.getStatusLine().toString());
         logger.error(errorMessage);

--- a/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/personprovider/OrcidProvider.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/personprovider/OrcidProvider.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import edu.kit.datamanager.ro_crate.entities.contextual.PersonEntity;
 import edu.kit.datamanager.ro_crate.entities.validation.EntityValidation;
 import edu.kit.datamanager.ro_crate.entities.validation.JsonSchemaValidation;
-import edu.kit.datamanager.ro_crate.externalproviders.organizationprovider.RorProvider;
 import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
 
 import java.io.IOException;

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/RoCrateReader.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/RoCrateReader.java
@@ -172,10 +172,20 @@ public class RoCrateReader {
     });
   }
 
+  /**
+   * Extracts the root entity from the graph, using the information from the
+   * descriptor.
+   * 
+   * Basically implements step 5 of the algorithm described here:
+   * https://www.researchobject.org/ro-crate/1.1/root-data-entity.html#finding-the-root-data-entity
+   * 
+   * @param graph      the graph from the metadata JSON-LD file
+   * @param descriptor the RO-Crate descriptor
+   * @return the root entity, if found
+   */
   private Optional<ObjectNode> extractRoot(ArrayNode graph, JsonNode descriptor) {
     String rootId = descriptor.get(PROP_ABOUT).get(PROP_ID).asText();
-    return StreamSupport.stream(graph.spliterator(), false)
-        // convert to object note, if it is an object
+        // root is an object (filter + conversion)
         .filter(JsonNode::isObject)
         .map(JsonNode::<ObjectNode>deepCopy)
         // "5. if the entity has an @id URI that matches root return it"

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/RoCrateReader.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/RoCrateReader.java
@@ -10,6 +10,7 @@ import edu.kit.datamanager.ro_crate.context.RoCrateMetadataContext;
 import edu.kit.datamanager.ro_crate.entities.contextual.ContextualEntity;
 import edu.kit.datamanager.ro_crate.entities.data.DataEntity;
 import edu.kit.datamanager.ro_crate.entities.data.RootDataEntity;
+import edu.kit.datamanager.ro_crate.special.JsonUtilFunctions;
 import edu.kit.datamanager.ro_crate.validation.JsonSchemaValidation;
 import edu.kit.datamanager.ro_crate.validation.Validator;
 
@@ -158,7 +159,7 @@ public class RoCrateReader {
         .findFirst();
 
     maybeDescriptor.ifPresent(descriptor -> {
-      removeJsonNodeFromArrayNode(graph, descriptor);
+      JsonUtilFunctions.removeJsonNodeFromArrayNode(graph, descriptor);
       setCrateDescriptor(crate, descriptor);
 
       Optional<ObjectNode> maybeRoot = extractRoot(graph, descriptor);
@@ -172,7 +173,7 @@ public class RoCrateReader {
                 .setHasPart(hasPartIds)
                 .build());
 
-        removeJsonNodeFromArrayNode(graph, root);
+        JsonUtilFunctions.removeJsonNodeFromArrayNode(graph, root);
       });
     });
   }
@@ -211,15 +212,6 @@ public class RoCrateReader {
       hasPartIds.add(hasPartNode.path(PROP_ID).asText());
     }
     return hasPartIds;
-  }
-
-  private void removeJsonNodeFromArrayNode(ArrayNode array, JsonNode node) {
-    for (int i = 0; i < array.size(); i++) {
-      if (array.get(i).equals(node)) {
-        array.remove(i);
-        return;
-      }
-    }
   }
 
   private void setCrateDescriptor(RoCrate crate, JsonNode descriptor) {

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/RoCrateReader.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/RoCrateReader.java
@@ -138,12 +138,10 @@ public class RoCrateReader {
    * We will need the root dataset to distinguish between data entities and
    * contextual entities.
    * 
-   * @param crate the crate, which will have the entities set, if available in the
+   * @param crate the crate, which will receive the entities, if available in the
    *              graph.
    * @param graph the graph of the Metadata JSON file, where the entities are
-   *              extracted from.
-   * @return the given graph, but without the root data entity and the Metadata
-   *         File Descriptor (JSON descriptor).
+   *              extracted and removed from.
    */
   protected void moveRootEntitiesFromGraphToCrate(RoCrate crate, ArrayNode graph) {
     // use the algorithm described here:

--- a/src/main/java/edu/kit/datamanager/ro_crate/special/CrateVersion.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/special/CrateVersion.java
@@ -53,7 +53,7 @@ public enum CrateVersion {
      * Private constructor which is being used for the internally given information
      * above.
      * 
-     * @param spec
+     * @param spec the specification URI / conformsTo value
      */
     private CrateVersion(String spec) {
         this.conformsTo = spec;

--- a/src/main/java/edu/kit/datamanager/ro_crate/special/CrateVersion.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/special/CrateVersion.java
@@ -92,4 +92,20 @@ public enum CrateVersion {
         }
         return null;
     }
+
+    public boolean isGreaterThan(CrateVersion other) {
+        return this.compareTo(other) > 0;
+    }
+
+    public boolean isGreaterOrEqualThan(CrateVersion other) {
+        return this.compareTo(other) >= 0;
+    }
+
+    public boolean isLowerThan(CrateVersion other) {
+        return this.compareTo(other) < 0;
+    }
+
+    public boolean isLowerOrEqualThan(CrateVersion other) {
+        return this.compareTo(other) <= 0;
+    }
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/special/CrateVersion.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/special/CrateVersion.java
@@ -1,0 +1,94 @@
+package edu.kit.datamanager.ro_crate.special;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+
+/**
+ * Represents a crate version and has information for each version available.
+ * 
+ * It offers also convenience functionality like version comparison using
+ * "<", "==", "<=", etc.
+ */
+public enum CrateVersion {
+    // NOTE: Java defines compareTo for enums to work in the order of the defined
+    // elements. This means higher versions have to be defined below the lower
+    // versions. Consider this when adding a new version.
+    //
+    // NOTE: To add a new version, simply append a new variant with the correct
+    // data and read the comment below the versions.
+    V1P1("https://w3id.org/ro/crate/1.1"),
+    V1P2_DRAFT("https://w3id.org/ro/crate/1.2-DRAFT");
+    // NOTE: Do not forget to adjust the following when adding a version:
+    public static final CrateVersion LATEST_STABLE = CrateVersion.V1P1;
+    public static final CrateVersion LATEST_UNSTABLE = CrateVersion.V1P2_DRAFT;
+
+    /**
+     * The String which is referred to by the crates conformsTo value.
+     * Should lead to the specification when resolved as a URL.
+     */
+    public final String conformsTo;
+
+    /**
+     * The String representation of the version.
+     * 
+     * Example: assertEquals("1.2-DRAFT", CrateVersion.V1P2_DRAFT);
+     */
+    public final String version;
+
+    /**
+     * Basically a constructor of a version, if it needs to be created from the spec
+     * URI.
+     * 
+     * @param conformsTo the specification URI. Example:
+     *                   https://w3id.org/ro/crate/1.1
+     * @return the matching CrateVersion enum, if the URI matches any. Empty if not.
+     */
+    public Optional<CrateVersion> fromSpecUri(String conformsTo) {
+        return Optional.ofNullable(crateVersionOfConformsTo(conformsTo));
+    }
+
+    /**
+     * Private constructor which is being used for the internally given information
+     * above.
+     * 
+     * @param spec
+     */
+    private CrateVersion(String spec) {
+        this.conformsTo = spec;
+        this.version = getVersionFromConformsToString(spec);
+    }
+
+    public boolean isStable() {
+        return !this.version.endsWith("-DRAFT");
+    }
+
+    public URI getConformsToUri() {
+        try {
+            return new URI(this.conformsTo);
+        } catch (URISyntaxException e) {
+            // can not happen as the user can not set this string
+            return null;
+        }
+    }
+
+    /**
+     * Extracts the version from the spec uri.
+     * 
+     * @param specUri the uri of the spec
+     * @return the version of the spec
+     */
+    private static String getVersionFromConformsToString(String specUri) {
+        String[] parts = specUri.split("/");
+        return parts[parts.length - 1];
+    }
+
+    private static CrateVersion crateVersionOfConformsTo(String conformsTo) {
+        for (CrateVersion e : values()) {
+            if (e.conformsTo.equals(conformsTo)) {
+                return e;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/edu/kit/datamanager/ro_crate/special/CrateVersion.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/special/CrateVersion.java
@@ -45,7 +45,7 @@ public enum CrateVersion {
      *                   https://w3id.org/ro/crate/1.1
      * @return the matching CrateVersion enum, if the URI matches any. Empty if not.
      */
-    public Optional<CrateVersion> fromSpecUri(String conformsTo) {
+    public static Optional<CrateVersion> fromSpecUri(String conformsTo) {
         return Optional.ofNullable(crateVersionOfConformsTo(conformsTo));
     }
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/special/CrateVersion.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/special/CrateVersion.java
@@ -7,8 +7,8 @@ import java.util.Optional;
 /**
  * Represents a crate version and has information for each version available.
  * 
- * It offers also convenience functionality like version comparison using
- * "<", "==", "<=", etc.
+ * It offers also convenience functionality like version comparison similar to
+ * numbers.
  */
 public enum CrateVersion {
     // NOTE: Java defines compareTo for enums to work in the order of the defined
@@ -19,6 +19,7 @@ public enum CrateVersion {
     // data and read the comment below the versions.
     V1P1("https://w3id.org/ro/crate/1.1"),
     V1P2_DRAFT("https://w3id.org/ro/crate/1.2-DRAFT");
+
     // NOTE: Do not forget to adjust the following when adding a version:
     public static final CrateVersion LATEST_STABLE = CrateVersion.V1P1;
     public static final CrateVersion LATEST_UNSTABLE = CrateVersion.V1P2_DRAFT;

--- a/src/main/java/edu/kit/datamanager/ro_crate/special/JsonUtilFunctions.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/special/JsonUtilFunctions.java
@@ -122,4 +122,22 @@ public class JsonUtilFunctions {
     }
     return set;
   }
+
+  /**
+   * Removes the first instance in the given array that equals the given node.
+   * 
+   * @param array the array from which to remove the node
+   * @param node  the node to remove
+   * @return true if an equal node was found and removed, false if no equal node
+   *         was found.
+   */
+  public static boolean removeJsonNodeFromArrayNode(ArrayNode array, JsonNode node) {
+    for (int i = 0; i < array.size(); i++) {
+      if (array.get(i).equals(node)) {
+        array.remove(i);
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/BuilderSpec12Test.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/BuilderSpec12Test.java
@@ -1,0 +1,28 @@
+package edu.kit.datamanager.ro_crate.crate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import edu.kit.datamanager.ro_crate.Crate;
+import edu.kit.datamanager.ro_crate.RoCrate;
+
+class BuilderSpec12Test {
+    @Test
+    void testAppendConformsTo() throws URISyntaxException {
+        Crate crate = new RoCrate.BuilderV1p2Draft()
+            .alsoConformsTo(new URI("https://w3id.org/ro/wfrun/process/0.1"))
+            .alsoConformsTo(new URI("https://example.com/myprofile/1.0"))
+            .build();
+        JsonNode conformsTo = crate.getJsonDescriptor().getProperty("conformsTo");
+        assertTrue(conformsTo.isArray());
+        // one version and two profiles
+        assertEquals(1 + 2, conformsTo.size());
+    }
+}

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/BuilderSpec12Test.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/BuilderSpec12Test.java
@@ -1,10 +1,12 @@
 package edu.kit.datamanager.ro_crate.crate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collection;
 
 import org.junit.jupiter.api.Test;
 
@@ -12,17 +14,69 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import edu.kit.datamanager.ro_crate.Crate;
 import edu.kit.datamanager.ro_crate.RoCrate;
+import edu.kit.datamanager.ro_crate.entities.contextual.ContextualEntity;
+import edu.kit.datamanager.ro_crate.reader.FolderReader;
+import edu.kit.datamanager.ro_crate.reader.RoCrateReader;
+import edu.kit.datamanager.ro_crate.special.CrateVersion;
+import edu.kit.datamanager.ro_crate.validation.JsonSchemaValidation;
+import edu.kit.datamanager.ro_crate.validation.Validator;
 
 class BuilderSpec12Test {
+    private URI profile1;
+    private URI profile2;
+
     @Test
     void testAppendConformsTo() throws URISyntaxException {
-        Crate crate = new RoCrate.BuilderV1p2Draft()
-            .alsoConformsTo(new URI("https://w3id.org/ro/wfrun/process/0.1"))
-            .alsoConformsTo(new URI("https://example.com/myprofile/1.0"))
-            .build();
+        Crate crate = new RoCrate.BuilderWithDraftFeatures()
+                .alsoConformsTo(new URI("https://w3id.org/ro/wfrun/process/0.1"))
+                .alsoConformsTo(new URI("https://example.com/myprofile/1.0"))
+                .build();
         JsonNode conformsTo = crate.getJsonDescriptor().getProperty("conformsTo");
         assertTrue(conformsTo.isArray());
         // one version and two profiles
         assertEquals(1 + 2, conformsTo.size());
+    }
+
+    @Test
+    void testModificationOfDraftCrate() throws URISyntaxException {
+        String path = this.getClass().getResource("/crates/spec-1.2-DRAFT/minimal-with-conformsTo-Array").getPath();
+        RoCrate crate = new RoCrateReader(new FolderReader()).readCrate(path);
+        Collection<String> existingProfiles = crate.getProfiles();
+        profile1 = new URI("https://example.com/myprofile/1.0");
+        profile2 = new URI("https://example.com/myprofile/2.0");
+        // the loaded crate has at least one profile
+        assertFalse(existingProfiles.isEmpty());
+        // and the ones we will add later are not part of it
+        assertFalse(existingProfiles.contains(profile1.toString()));
+        assertFalse(existingProfiles.contains(profile2.toString()));
+
+        // add profiles
+        RoCrate modifiedCrate = new RoCrate.BuilderWithDraftFeatures(crate)
+                .alsoConformsTo(profile1)
+                .alsoConformsTo(profile2)
+                .addContextualEntity(new ContextualEntity.ContextualEntityBuilder()
+                        .addType("CreativeWork")
+                        .build())
+                .build();
+        
+        // sanity checks
+        Validator defaultValidation = new Validator(new JsonSchemaValidation());
+        assertTrue(defaultValidation.validate(modifiedCrate));
+        assertEquals(CrateVersion.LATEST_UNSTABLE, crate.getVersion().get());
+        assertEquals(CrateVersion.LATEST_UNSTABLE, modifiedCrate.getVersion().get());
+        
+        // number of profiles increased by 2
+        Collection<String> newProfileState = modifiedCrate.getProfiles();
+        assertEquals(existingProfiles.size() + 2, newProfileState.size());
+        // new profiles are present
+        newProfileState.contains(profile1.toString());
+        newProfileState.contains(profile2.toString());
+        // old profiles are present
+        assertEquals(
+            0,
+            existingProfiles.stream()
+                .filter(txt -> !newProfileState.contains(txt))
+                .count()
+        );
     }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/RoCrateReaderSpec12Test.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/RoCrateReaderSpec12Test.java
@@ -1,0 +1,46 @@
+package edu.kit.datamanager.ro_crate.reader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.StreamSupport;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import edu.kit.datamanager.ro_crate.Crate;
+
+/**
+ * These reading tests are specific for reading 1.2 compliant crates.
+ * 
+ * They will refer to 1.2-DRAFT as long as the specification is not final.
+ * Base for these tests are usually examples from the specification, but may
+ * contain modifications if no example for a certain property is given.
+ * 
+ * Current specification: https://www.researchobject.org/ro-crate/1.2-DRAFT/
+ */
+public class RoCrateReaderSpec12Test {
+
+    /**
+     * Test reading a minimal crate with multiple conformsTo values, as described in
+     * https://www.researchobject.org/ro-crate/1.2-DRAFT/profiles.html#declaring-conformance-of-an-ro-crate-profile
+     */
+    @Test
+    void testReadingCrateWithConformsToArray() {
+        String path = this.getClass().getResource("/crates/spec-1.2-DRAFT/minimal-with-conformsTo-Array").getPath();
+        Crate crate = new RoCrateReader(new FolderReader()).readCrate(path);
+        JsonNode conformsTo = crate.getJsonDescriptor().getProperty("conformsTo");
+        assertTrue(conformsTo.isArray());
+        assertEquals(2, conformsTo.size());
+        // filter the list to only contain the two expected values and expect no changes
+        long numFiltered = StreamSupport.stream(conformsTo.spliterator(), false)
+                .filter(node -> {
+                    String asText = node.path("@id").asText();
+                    return asText.equals("https://w3id.org/ro/crate/1.2-DRAFT")
+                            || asText.equals("https://example.com/my/profile/1.0-TEST");
+                })
+                .count();
+        assertEquals(2, numFiltered);
+    }
+}

--- a/src/test/java/edu/kit/datamanager/ro_crate/special/CrateVersionTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/special/CrateVersionTest.java
@@ -1,0 +1,64 @@
+package edu.kit.datamanager.ro_crate.special;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+public class CrateVersionTest {
+
+    @Test
+    public void testIsGreaterThan() {
+        assertTrue(CrateVersion.V1P2_DRAFT.isGreaterThan(CrateVersion.V1P1));
+        assertFalse(CrateVersion.V1P1.isGreaterThan(CrateVersion.V1P2_DRAFT));
+    }
+
+    @Test
+    public void testIsGreaterOrEqualThan() {
+        assertTrue(CrateVersion.LATEST_UNSTABLE.isGreaterOrEqualThan(CrateVersion.LATEST_STABLE));
+        assertTrue(CrateVersion.V1P2_DRAFT.isGreaterOrEqualThan(CrateVersion.V1P1));
+        assertFalse(CrateVersion.V1P1.isGreaterOrEqualThan(CrateVersion.V1P2_DRAFT));
+    }
+
+    @Test
+    public void testIsLowerThan() {
+        assertTrue(CrateVersion.V1P1.isLowerThan(CrateVersion.V1P2_DRAFT));
+        assertFalse(CrateVersion.V1P2_DRAFT.isLowerThan(CrateVersion.V1P1));
+    }
+
+    @Test
+    public void testIsLowerOrEqualThan() {
+        assertTrue(CrateVersion.LATEST_STABLE.isLowerOrEqualThan(CrateVersion.LATEST_UNSTABLE));
+        assertTrue(CrateVersion.V1P1.isLowerOrEqualThan(CrateVersion.V1P2_DRAFT));
+        assertFalse(CrateVersion.V1P2_DRAFT.isLowerOrEqualThan(CrateVersion.V1P1));
+    }
+
+    @Test
+    void testFromSpecUri() {
+        // fromSpecUri has to work with the internally stored values
+        Arrays.stream(CrateVersion.values())
+                .forEach(version -> assertTrue(CrateVersion.fromSpecUri(version.conformsTo).isPresent()));
+        // but it has to fail for other values
+        assertTrue(CrateVersion.fromSpecUri("https://example.com/my/profile/1.1").isEmpty());
+    }
+
+    @Test
+    void testGetConformsToUri() {
+        // getConformsToUri assumes internally to never throw, and therefore to never
+        // return null.
+        Arrays.stream(CrateVersion.values())
+                .forEach(version -> assertNotNull(version));
+    }
+
+    @Test
+    void testIsStable() {
+        assertTrue(CrateVersion.LATEST_STABLE.isStable());
+        assertTrue(CrateVersion.V1P1.isStable());
+
+        assertFalse(CrateVersion.LATEST_UNSTABLE.isStable());
+        assertFalse(CrateVersion.V1P2_DRAFT.isStable());
+    }
+}

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateWriterSpec12Test.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateWriterSpec12Test.java
@@ -1,0 +1,57 @@
+package edu.kit.datamanager.ro_crate.writer;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import edu.kit.datamanager.ro_crate.Crate;
+import edu.kit.datamanager.ro_crate.HelpFunctions;
+import edu.kit.datamanager.ro_crate.reader.FolderReader;
+import edu.kit.datamanager.ro_crate.reader.RoCrateReader;
+
+class RoCrateWriterSpec12Test {
+
+    @Test
+    void writeDoesNotModifyTest(@TempDir Path tempDir) throws IOException, URISyntaxException {
+        // read crate (not the actual part of this test)
+        String internalOriginalCratePath = "crates/spec-1.2-DRAFT/minimal-with-conformsTo-Array";
+        URL internalOriginalCrateURL = this.getClass().getResource("/" + internalOriginalCratePath);
+        assertNotNull(internalOriginalCrateURL);
+
+        Crate crate = new RoCrateReader(new FolderReader()).readCrate(internalOriginalCrateURL.getPath());
+        Path targetDir = tempDir.resolve("spec12writeUnmodified");
+
+        {
+            // save to disk
+            RoCrateWriter folderRoCrateWriter = new RoCrateWriter(new FolderWriter());
+            folderRoCrateWriter.save(crate, targetDir.toFile().getPath());
+        }
+
+        // compare directories
+        Path srcDir = Paths.get(internalOriginalCrateURL.toURI());
+        assertTrue(HelpFunctions.compareTwoDir(targetDir.toFile(), srcDir.toFile()));
+
+        // compare original metadata file with crate class
+        HelpFunctions.compareCrateJsonToFileInResources(
+                crate,
+                "/" + internalOriginalCratePath + "/ro-crate-metadata.json");
+        // compare exported metadata file with original metadata file
+        HelpFunctions.compareCrateJsonToFileInResources(
+                // created metadata file
+                targetDir.resolve("ro-crate-metadata.json").toFile(),
+                // original metadata file
+                new File(srcDir.resolve("ro-crate-metadata.json").toString()));
+        // Compare loaded crate object with crate object made of export
+        Crate crate2 = new RoCrateReader(new FolderReader()).readCrate(targetDir.toString());
+        HelpFunctions.compareTwoCrateJson(crate, crate2);
+    }
+}

--- a/src/test/resources/crates/spec-1.2-DRAFT/minimal-with-conformsTo-Array/ro-crate-metadata.json
+++ b/src/test/resources/crates/spec-1.2-DRAFT/minimal-with-conformsTo-Array/ro-crate-metadata.json
@@ -1,0 +1,38 @@
+{
+    "@context": "https://w3id.org/ro/crate/1.2-DRAFT/context",
+    "@graph": [
+        {
+            "@type": "CreativeWork",
+            "@id": "ro-crate-metadata.json",
+            "about": {
+                "@id": "./"
+            },
+            "conformsTo": [
+                {
+                    "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+                },
+                {
+                    "@id": "https://example.com/my/profile/1.0-TEST"
+                }
+            ]
+        },
+        {
+            "@id": "./",
+            "identifier": "https://doi.org/10.4225/59/59672c09f4a4b",
+            "@type": "Dataset",
+            "datePublished": "2017",
+            "name": "Data files associated with the manuscript:Effects of facilitated family case conferencing for ...",
+            "description": "Palliative care planning for nursing home residents with advanced dementia ...",
+            "license": {
+                "@id": "https://creativecommons.org/licenses/by-nc-sa/3.0/au/"
+            }
+        },
+        {
+            "@id": "https://creativecommons.org/licenses/by-nc-sa/3.0/au/",
+            "@type": "CreativeWork",
+            "description": "This work is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Australia License. To view a copy of this license, visit http://creativecommons.org/licenses/by-nc-sa/3.0/au/ or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.",
+            "identifier": "https://creativecommons.org/licenses/by-nc-sa/3.0/au/",
+            "name": "Attribution-NonCommercial-ShareAlike 3.0 Australia (CC BY-NC-SA 3.0 AU)"
+        }
+    ]
+}


### PR DESCRIPTION
- [x] refactor the function which caused the issue
  - [x] test still run locally
  - [x] tests still run in CI https://github.com/kit-data-manager/ro-crate-java/pull/111/commits/ffaacf45a7d41d961afcf67788764f5b34d04776 https://github.com/kit-data-manager/ro-crate-java/actions/runs/4895529104
- [x] Support reading 1.2-DRAFT crates
  - [x] Create a test which reads a 1.2-DRAFT Metadata file
  - [x] implementation
  - [x] Create a test which writes the crate after reading, showing that nothing changed
  - [x] Test: Compare loaded crate from original and from copy
- [x] Support on crate creation to choose the specification version (1.2-DRAFT will after stabilization be the same as 1.2, we do not plan to support the creation of draft versions where stable/newer versions exist)
  - [x] test
  - [x] implementation
    - Note: ideally, something like "appendProfile(...)" would only be available to descriptors containing the 1.2(-DRAFT) profile.
- [x] Support modification of 1.2-DRAFT crates profiles (conformsTo array)
  - [x] write test for modification
  - [x] test: ensure we do modify it, not overwrite the descriptor
  - [x] implementation
    - [x] methods exist in builder
    - [x] can put crate into v1.2 builder
- [x] Support a mechanism to upgrade from 1.1 to 1.2-DRAFT (as far as possible, here at least regarding the amount of conformsTo values, other changes may be supported in later PRs)
  - implementation is implied by modification
- [x] Update Readme about supported versions and examples

Further resources:

- [1.2-DRAFT changelog](https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/changelog.html)
- [Other 1.2-DRAFT related information relevant for implementations](https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/)