### PR TITLE
Fix issues with crate reader

### DIFF
--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataEntity.java
@@ -118,7 +118,7 @@ public class DataEntity extends AbstractEntity {
         public T addContent(URI uri) {
             if (isUrl(uri.toString())) {
                 this.setId(uri.toString());
-            }
+            } else throw new IllegalArgumentException("This Data Entity remote ID does not resolve to a valid URL.");
             return self();
         }
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/RoCrateReader.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/RoCrateReader.java
@@ -127,6 +127,7 @@ public class RoCrateReader {
   }
 
   protected File checkFolderHasFile(String id, File file) {
+    if (isUrl(id)) return null;
     Path path = file.toPath().resolve(decode(id).get());
     if (path.toFile().exists()) {
       return path.toFile();

--- a/src/main/java/edu/kit/datamanager/ro_crate/special/UriUtil.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/special/UriUtil.java
@@ -56,7 +56,11 @@ public class UriUtil {
      * @return true if it is a url, false otherwise.
      */
     public static boolean isUrl(String uri) {
-        return asUrl(uri).isPresent();
+        try {
+            return asUrl(uri).isPresent();
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes two issues in RoCrateReader.java:

- Data entities without a corresponding file (for example entities describing an online ressource) were automatically removed
- Windows only allows specific symbols for paths. Checking if a file with the name of a URL exists results in a crash on windows