### PR TITLE
More ergonomic and consistent ActionEntityBuilder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ ext {
 
 dependencies {
     // JUnit setup for testing
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.11.0-RC1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params'
     testImplementation(platform("org.junit:junit-bom:5.10.3"))
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
@@ -271,7 +271,7 @@ public class AbstractEntity {
      * @param name the key of the property.
      * @param stringList List containing all the id as String.
      */
-    public void addIdListProperties(String name, List<String> stringList) {
+    public void addIdListProperties(String name, Collection<String> stringList) {
         ObjectMapper objectMapper = MyObjectMapper.getMapper();
         ArrayNode node = objectMapper.createArrayNode();
         if (this.properties.get(name) == null) {

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntity.java
@@ -2,6 +2,7 @@ package edu.kit.datamanager.ro_crate.entities.contextual;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Optional;
 
 /**
  * This class represents a detailing provenance of entities.
@@ -23,6 +24,7 @@ public class ActionEntity extends ContextualEntity {
         this.addDateTimeProperty("startTime", entityBuilder.startTime);
         this.addDateTimeProperty("endTime", entityBuilder.endTime);
 
+        entityBuilder.status.ifPresent(status -> this.addIdProperty("actionStatus", status.getId()));
         this.addIdProperty("agent", entityBuilder.agent);
         this.addIdListProperties("instrument", entityBuilder.instruments);
         this.addIdListProperties("result", entityBuilder.results);
@@ -32,18 +34,19 @@ public class ActionEntity extends ContextualEntity {
     abstract static class AbstractActionEntityBuilder<T extends AbstractActionEntityBuilder<T>>
             extends AbstractContextualEntityBuilder<T> {
 
-        protected ActionTypeEnum type;
+        protected ActionType type;
         protected String description;
         protected String name;
         protected String startTime;
         protected String endTime;
         protected String agent;
+        protected Optional<ActionStatus> status = Optional.empty();
 
         protected Collection<String> objects = new HashSet<>();
         protected Collection<String> results = new HashSet<>();
         protected Collection<String> instruments = new HashSet<>();
 
-        protected AbstractActionEntityBuilder(ActionTypeEnum type) {
+        protected AbstractActionEntityBuilder(ActionType type) {
             this.type = type;
         }
 
@@ -69,6 +72,11 @@ public class ActionEntity extends ContextualEntity {
 
         public T setAgent(String agent) {
             this.agent = agent;
+            return self();
+        }
+
+        public T setStatus(ActionStatus status) {
+            this.status = Optional.ofNullable(status);
             return self();
         }
 
@@ -166,7 +174,7 @@ public class ActionEntity extends ContextualEntity {
     public static final class ActionEntityBuilder
             extends AbstractActionEntityBuilder<ActionEntityBuilder> {
 
-        public ActionEntityBuilder(ActionTypeEnum type) {
+        public ActionEntityBuilder(ActionType type) {
             super(type);
         }
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntity.java
@@ -4,7 +4,11 @@ import java.util.Collection;
 import java.util.HashSet;
 
 /**
- * This class helps to generate a detailing provenance of entities.
+ * This class represents a detailing provenance of entities.
+ * 
+ * Relevant specification link: <a href=
+ * "https://www.researchobject.org/ro-crate/specification/1.1/provenance.html">Provenance
+ * of entities</a>
  * 
  * @author sabrinechelbi
  */
@@ -69,9 +73,14 @@ public class ActionEntity extends ContextualEntity {
         }
 
         /**
-         * Same as calling {@link #addObject(String)} with each element of the collection.
+         * Same as calling {@link #addObject(String)} with each element of the
+         * collection.
          * 
-         * @param objects the objects to add to this ActionEntity
+         * From the specification: "A curation Action MUST have at least one object
+         * which associates it with either the root data entity Dataset or one of its
+         * components."
+         * 
+         * @param objects see {@link #addObject(String)}
          * @return this builder
          */
         public T addObjects(Collection<String> objects) {
@@ -82,8 +91,16 @@ public class ActionEntity extends ContextualEntity {
         /**
          * Adds a object to the collection of objects of this ActionEntity.
          * 
+         * From the specification: "A curation Action MUST have at least one object
+         * which associates it with either the root data entity Dataset or one of its
+         * components."
+         * 
          * @param object the object to add to this ActionEntity. Duplicates will be
-         *               ignored/removed.
+         *               ignored/removed. "The object upon which the action is carried
+         *               out, whose state is kept intact or changed. Also known as the
+         *               semantic roles patient, affected or undergoer (which change
+         *               their state) or theme (which doesn't). E.g. John read a book."
+         *               (Schema.org definition)
          * @return this builder
          */
         public T addObject(String object) {
@@ -92,9 +109,10 @@ public class ActionEntity extends ContextualEntity {
         }
 
         /**
-         * Same as calling {@link #addResult(String)} with each element of the collection.
+         * Same as calling {@link #addResult(String)} with each element of the
+         * collection.
          * 
-         * @param results the results to add to this ActionEntity
+         * @param results see {@link #addResult(String)}
          * @return this builder
          */
         public T addResults(Collection<String> results) {
@@ -105,7 +123,9 @@ public class ActionEntity extends ContextualEntity {
         /**
          * Adds a result to the collection of results of this ActionEntity.
          * 
-         * @param result the result to add to this ActionEntity. Duplicates will be ignored/removed.
+         * @param result the result to add to this ActionEntity. Duplicates will be
+         *               ignored/removed. "The result produced in the action. E.g. John
+         *               wrote a book." (Schema.org definition)
          * @return this builder
          */
         public T addResult(String result) {
@@ -114,9 +134,10 @@ public class ActionEntity extends ContextualEntity {
         }
 
         /**
-         * Same as calling {@link #addInstrument(String)} with each element of the collection.
+         * Same as calling {@link #addInstrument(String)} with each element of the
+         * collection.
          * 
-         * @param results the results to add to this ActionEntity
+         * @param see {@link #addInstrument(String)}
          * @return this builder
          */
         public T addInstruments(Collection<String> instruments) {
@@ -127,7 +148,10 @@ public class ActionEntity extends ContextualEntity {
         /**
          * Adds a instrument to the collection of instruments of this ActionEntity.
          * 
-         * @param instrument the instrument to add to this ActionEntity. Duplicates will be ignored/removed.
+         * @param instrument the instrument to add to this ActionEntity. Duplicates will
+         *                   be ignored/removed. "The object that helped the agent
+         *                   perform the action. E.g. John wrote a book with a pen."
+         *                   (Schema.org definition)
          * @return this builder
          */
         public T addInstrument(String instrument) {

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntity.java
@@ -19,67 +19,80 @@ public class ActionEntity extends ContextualEntity {
         this.addDateTimeProperty("endTime", entityBuilder.endTime);
 
         this.addIdProperty("agent", entityBuilder.agent);
-        this.addIdListProperties("instrument", entityBuilder.instrument);
-        this.addIdListProperties("result", entityBuilder.result);
-        this.addIdListProperties("object", entityBuilder.object);
+        this.addIdListProperties("instrument", entityBuilder.instruments);
+        this.addIdListProperties("result", entityBuilder.results);
+        this.addIdListProperties("object", entityBuilder.objects);
     }
 
     abstract static class AbstractActionEntityBuilder<T extends AbstractActionEntityBuilder<T>>
             extends AbstractContextualEntityBuilder<T> {
 
-        ActionTypeEnum type;
-        String description;
-        String name;
-        String startTime;
-        String endTime;
-        String agent;
+        private ActionTypeEnum type;
+        private String description;
+        private String name;
+        private String startTime;
+        private String endTime;
+        private String agent;
 
-        List<String> object = new ArrayList<>();
-        List<String> result = new ArrayList<>();
-        List<String> instrument = new ArrayList<>();
+        List<String> objects = new ArrayList<>();
+        List<String> results = new ArrayList<>();
+        List<String> instruments = new ArrayList<>();
 
-        public T addType(ActionTypeEnum type) {
+        protected AbstractActionEntityBuilder(ActionTypeEnum type) {
             this.type = type;
-            return self();
         }
 
-        public T addDescription(String description) {
+        public T setDescription(String description) {
             this.description = description;
             return self();
         }
 
-        public T addName(String name) {
+        public T setName(String name) {
             this.name = name;
             return self();
         }
 
-        public T addStartTime(String startTime) {
+        public T setStartTime(String startTime) {
             this.startTime = startTime;
             return self();
         }
 
-        public T addEndTime(String endTime) {
+        public T setEndTime(String endTime) {
             this.endTime = endTime;
             return self();
         }
 
-        public T addAgent(String agent) {
+        public T setAgent(String agent) {
             this.agent = agent;
             return self();
         }
 
-        public T addObject(List<String> object) {
-            this.object = object;
+        public T addObjects(List<String> objects) {
+            this.objects.addAll(objects);
             return self();
         }
 
-        public T addResult(List<String> result) {
-            this.result = result;
+        public T addObject(String object) {
+            this.objects.add(object);
             return self();
         }
 
-        public T addInstrument(List<String> instrument) {
-            this.instrument = instrument;
+        public T addResults(List<String> results) {
+            this.results.addAll(results);
+            return self();
+        }
+        public T addResult(String result) {
+            this.results.add(result);
+            return self();
+        }
+
+        public T addInstruments(List<String> instruments) {
+            this.instruments.addAll(instruments);
+            return self();
+        }
+
+        public T addInstrument(String instrument) {
+            this.instruments.add(instrument);
             return self();
         }
 
@@ -89,6 +102,10 @@ public class ActionEntity extends ContextualEntity {
 
     public static final class ActionEntityBuilder
             extends AbstractActionEntityBuilder<ActionEntityBuilder> {
+
+        public ActionEntityBuilder(ActionTypeEnum type) {
+            super(type);
+        }
 
         @Override
         public ActionEntityBuilder self() {

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntity.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 
 /**
  * This class helps to generate a detailing provenance of entities.
+ * 
  * @author sabrinechelbi
  */
 public class ActionEntity extends ContextualEntity {
@@ -27,16 +28,16 @@ public class ActionEntity extends ContextualEntity {
     abstract static class AbstractActionEntityBuilder<T extends AbstractActionEntityBuilder<T>>
             extends AbstractContextualEntityBuilder<T> {
 
-        private ActionTypeEnum type;
-        private String description;
-        private String name;
-        private String startTime;
-        private String endTime;
-        private String agent;
+        protected ActionTypeEnum type;
+        protected String description;
+        protected String name;
+        protected String startTime;
+        protected String endTime;
+        protected String agent;
 
-        Collection<String> objects = new HashSet<>();
-        Collection<String> results = new HashSet<>();
-        Collection<String> instruments = new HashSet<>();
+        protected Collection<String> objects = new HashSet<>();
+        protected Collection<String> results = new HashSet<>();
+        protected Collection<String> instruments = new HashSet<>();
 
         protected AbstractActionEntityBuilder(ActionTypeEnum type) {
             this.type = type;
@@ -67,30 +68,68 @@ public class ActionEntity extends ContextualEntity {
             return self();
         }
 
+        /**
+         * Same as calling {@link #addObject(String)} with each element of the collection.
+         * 
+         * @param objects the objects to add to this ActionEntity
+         * @return this builder
+         */
         public T addObjects(Collection<String> objects) {
             this.objects.addAll(objects);
             return self();
         }
 
+        /**
+         * Adds a object to the collection of objects of this ActionEntity.
+         * 
+         * @param object the object to add to this ActionEntity. Duplicates will be
+         *               ignored/removed.
+         * @return this builder
+         */
         public T addObject(String object) {
             this.objects.add(object);
             return self();
         }
 
+        /**
+         * Same as calling {@link #addResult(String)} with each element of the collection.
+         * 
+         * @param results the results to add to this ActionEntity
+         * @return this builder
+         */
         public T addResults(Collection<String> results) {
             this.results.addAll(results);
             return self();
         }
+
+        /**
+         * Adds a result to the collection of results of this ActionEntity.
+         * 
+         * @param result the result to add to this ActionEntity. Duplicates will be ignored/removed.
+         * @return this builder
+         */
         public T addResult(String result) {
             this.results.add(result);
             return self();
         }
 
+        /**
+         * Same as calling {@link #addInstrument(String)} with each element of the collection.
+         * 
+         * @param results the results to add to this ActionEntity
+         * @return this builder
+         */
         public T addInstruments(Collection<String> instruments) {
             this.instruments.addAll(instruments);
             return self();
         }
 
+        /**
+         * Adds a instrument to the collection of instruments of this ActionEntity.
+         * 
+         * @param instrument the instrument to add to this ActionEntity. Duplicates will be ignored/removed.
+         * @return this builder
+         */
         public T addInstrument(String instrument) {
             this.instruments.add(instrument);
             return self();

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntity.java
@@ -145,7 +145,7 @@ public class ActionEntity extends ContextualEntity {
          * Same as calling {@link #addInstrument(String)} with each element of the
          * collection.
          * 
-         * @param see {@link #addInstrument(String)}
+         * @param instruments see {@link #addInstrument(String)}
          * @return this builder
          */
         public T addInstruments(Collection<String> instruments) {

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntity.java
@@ -1,7 +1,7 @@
 package edu.kit.datamanager.ro_crate.entities.contextual;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
+import java.util.HashSet;
 
 /**
  * This class helps to generate a detailing provenance of entities.
@@ -34,9 +34,9 @@ public class ActionEntity extends ContextualEntity {
         private String endTime;
         private String agent;
 
-        List<String> objects = new ArrayList<>();
-        List<String> results = new ArrayList<>();
-        List<String> instruments = new ArrayList<>();
+        Collection<String> objects = new HashSet<>();
+        Collection<String> results = new HashSet<>();
+        Collection<String> instruments = new HashSet<>();
 
         protected AbstractActionEntityBuilder(ActionTypeEnum type) {
             this.type = type;
@@ -67,7 +67,7 @@ public class ActionEntity extends ContextualEntity {
             return self();
         }
 
-        public T addObjects(List<String> objects) {
+        public T addObjects(Collection<String> objects) {
             this.objects.addAll(objects);
             return self();
         }
@@ -77,7 +77,7 @@ public class ActionEntity extends ContextualEntity {
             return self();
         }
 
-        public T addResults(List<String> results) {
+        public T addResults(Collection<String> results) {
             this.results.addAll(results);
             return self();
         }
@@ -86,7 +86,7 @@ public class ActionEntity extends ContextualEntity {
             return self();
         }
 
-        public T addInstruments(List<String> instruments) {
+        public T addInstruments(Collection<String> instruments) {
             this.instruments.addAll(instruments);
             return self();
         }

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionStatus.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionStatus.java
@@ -1,0 +1,18 @@
+package edu.kit.datamanager.ro_crate.entities.contextual;
+
+public enum ActionStatus {
+    ACTIVE_ACTION_STATUS("http://schema.org/ActiveActionStatus"),
+    COMPLETED_ACTION_STATUS("http://schema.org/CompletedActionStatus"),
+    FAILED_ACTION_STATUS("http://schema.org/FailedActionStatus"),
+    POTENTIAL_ACTION_STATUS("http://schema.org/PotentialActionStatus");
+
+    private final String id;
+
+    ActionStatus(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+}

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionType.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionType.java
@@ -4,14 +4,14 @@ package edu.kit.datamanager.ro_crate.entities.contextual;
  * Enumeration class representing action types.
  * @author sabrinechelbi
  */
-public enum ActionTypeEnum {
+public enum ActionType {
 
     CREATE("CreateAction"),
     UPDATE("UpdateAction");
 
     private final String name;
 
-    ActionTypeEnum(String name) {
+    ActionType(String name) {
         this.name = name;
     }
     

--- a/src/performanceTest/java/edu/kit/datamanager/ro_crate/multiplecrates/MultipleCratesWriteAndRead.java
+++ b/src/performanceTest/java/edu/kit/datamanager/ro_crate/multiplecrates/MultipleCratesWriteAndRead.java
@@ -71,6 +71,7 @@ public class MultipleCratesWriteAndRead {
       RoCrateWriter writer = new RoCrateWriter(new FolderWriter());
       writer.save(crate, "crate" + i);
       RoCrateReader reader = new RoCrateReader(new FolderReader());
+      @SuppressWarnings("unused")
       RoCrate copy = (RoCrate) reader.readCrate("crate" + i);
     }
     Instant end = Instant.now();

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/realexamples/RealTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/realexamples/RealTest.java
@@ -4,7 +4,7 @@ import edu.kit.datamanager.ro_crate.Crate;
 import edu.kit.datamanager.ro_crate.HelpFunctions;
 import edu.kit.datamanager.ro_crate.RoCrate;
 import edu.kit.datamanager.ro_crate.entities.contextual.ActionEntity;
-import edu.kit.datamanager.ro_crate.entities.contextual.ActionTypeEnum;
+import edu.kit.datamanager.ro_crate.entities.contextual.ActionType;
 import edu.kit.datamanager.ro_crate.entities.contextual.ContextualEntity;
 import edu.kit.datamanager.ro_crate.entities.contextual.OrganizationEntity;
 import edu.kit.datamanager.ro_crate.entities.contextual.PersonEntity;
@@ -104,7 +104,7 @@ class RealTest {
                 .setGeo("#4241434-33413")
                 .build();
 
-        ActionEntity createAction = new ActionEntity.ActionEntityBuilder(ActionTypeEnum.CREATE)
+        ActionEntity createAction = new ActionEntity.ActionEntityBuilder(ActionType.CREATE)
                 .setId("#MeasurementCapture_23231")
                 .setAgent("creator")
                 .addInstrument("https://www.aeroqual.com/product/outdoor-portable-monitor-starter-kit")

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/realexamples/RealTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/realexamples/RealTest.java
@@ -106,17 +106,11 @@ public class RealTest {
                 .setGeo("#4241434-33413")
                 .build();
 
-        List<String> instrument = new ArrayList<>();
-        instrument.add("https://www.aeroqual.com/product/outdoor-portable-monitor-starter-kit");
-        List<String> result = new ArrayList<>();
-        result.add("measurements/");
-
-        ActionEntity createAction = new ActionEntity.ActionEntityBuilder()
+        ActionEntity createAction = new ActionEntity.ActionEntityBuilder(ActionTypeEnum.CREATE)
                 .setId("#MeasurementCapture_23231")
-                .addType(ActionTypeEnum.CREATE)
-                .addAgent("creator")
-                .addInstrument(instrument)
-                .addResult(result)
+                .setAgent("creator")
+                .addInstrument("https://www.aeroqual.com/product/outdoor-portable-monitor-starter-kit")
+                .addResult("measurements/")
                 .build();
 
         ContextualEntity geo = new ContextualEntity.ContextualEntityBuilder()

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/realexamples/RealTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/realexamples/RealTest.java
@@ -22,12 +22,11 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class RealTest {
+class RealTest {
 
+    @SuppressWarnings("java:S2699") // disable warning about missing assertions
     @Test
     void testWithIDRCProject(@TempDir Path temp) throws IOException {
 
@@ -59,11 +58,10 @@ public class RealTest {
         crate.deleteEntityById("new_file.txt");
 
         HelpFunctions.compareCrateJsonToFileInResources(crate, locationMetadataFile);
-        //  uncomment if want to see crate in local folder structure
     }
 
     @Test
-    void testRealExampleWithActions(@TempDir Path temp) throws IOException {
+    void testRealExampleWithActions() throws IOException {
         DataSetEntity dataSet = new DataSetEntity.DataSetBuilder()
                 .setId("measurements/")
                 .addProperty("name", "Measurement Data")
@@ -140,8 +138,8 @@ public class RealTest {
                 .build();
 
         HelpFunctions.compareCrateJsonToFileInResources(crate, "/json/crate/BiggerExample.json");
-        assertEquals(crate.getAllContextualEntities().size(), 7);
-        assertEquals(crate.getAllDataEntities().size(), 2);
+        assertEquals(7, crate.getAllContextualEntities().size());
+        assertEquals(2, crate.getAllDataEntities().size());
 
     }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntityTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntityTest.java
@@ -5,6 +5,8 @@ import edu.kit.datamanager.ro_crate.HelpFunctions;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
+import java.util.Arrays;
+
 import org.junit.jupiter.api.Test;
 
 /**
@@ -31,13 +33,53 @@ class ActionEntityTest {
         ActionEntity createAction = new ActionEntity.ActionEntityBuilder(ActionType.CREATE)
                 .setId("#DataCapture_wcc02")
                 .setAgent("https://orcid.org/0000-0002-1672-552X")
+
                 .addInstrument("https://confluence.csiro.au/display/ASL/Hovermap")
+                // or (duplications will be ignored):
+                .addInstruments(Arrays.asList("https://confluence.csiro.au/display/ASL/Hovermap"))
+                
                 .addObject("#victoria_arch")
+                // or (duplications will be ignored):
+                .addObjects(Arrays.asList("#victoria_arch"))
+
                 // note how we can add multiple items by simply repeating them.
                 .addResult("wcc02_arch.laz")
                 .addResult("wcc02_arch_traj.txt")
+                // adding the same items will not duplicate them:
+                .addResults(Arrays.asList("wcc02_arch.laz", "wcc02_arch_traj.txt"))
                 .setStartTime("2017-06-10T12:56:14+10:00")
                 .setEndTime("2017-06-11T12:56:14+10:00")
+                .build();
+        
+        assertNotNull(createAction);
+        HelpFunctions.compareEntityWithFile(createAction, "/json/entities/contextual/createActionExample.json");
+    }
+
+    @Test
+    void testCreateActionGeneric() throws IOException {
+        
+        ContextualEntity equipment = new ContextualEntity.ContextualEntityBuilder()
+                .setId("https://confluence.csiro.au/display/ASL/Hovermap")
+                .addType("IndividualProduct")
+                .addProperty("description", "The CSIRO bentwing is an unmanned aerial vehicle (UAV, commonly known as a drone) with a LIDAR ... ")
+                .addProperty("name", "Bentwing")
+                .addIdProperty("manufacturer", "https://www.atlassian.com/software/confluence")
+                .addProperty("serialNumber", "1111122233321231")
+                .build();
+        
+        assertNotNull(equipment);
+        HelpFunctions.compareEntityWithFile(equipment, "/json/entities/contextual/equipment.json");
+
+        ActionEntity createAction = new ActionEntity.ActionEntityBuilder(ActionType.CREATE)
+                .setId("#DataCapture_wcc02")
+                .setAgent("https://orcid.org/0000-0002-1672-552X")
+
+                .addInstrument("https://confluence.csiro.au/display/ASL/Hovermap")
+                .addObject("#victoria_arch")
+                .addResult("wcc02_arch.laz")
+                .addResult("wcc02_arch_traj.txt")
+                .addDateTimeProperty("startTime","2017-06-10T12:56:14+10:00")
+                .addDateTimeProperty("endTime","2017-06-11T12:56:14+10:00")
                 .build();
         
         assertNotNull(createAction);

--- a/src/test/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntityTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntityTest.java
@@ -28,7 +28,7 @@ class ActionEntityTest {
         assertNotNull(equipment);
         HelpFunctions.compareEntityWithFile(equipment, "/json/entities/contextual/equipment.json");
 
-        ActionEntity createAction = new ActionEntity.ActionEntityBuilder(ActionTypeEnum.CREATE)
+        ActionEntity createAction = new ActionEntity.ActionEntityBuilder(ActionType.CREATE)
                 .setId("#DataCapture_wcc02")
                 .setAgent("https://orcid.org/0000-0002-1672-552X")
                 .addInstrument("https://confluence.csiro.au/display/ASL/Hovermap")
@@ -56,7 +56,7 @@ class ActionEntityTest {
         assertNotNull(software);
         HelpFunctions.compareEntityWithFile(software, "/json/entities/contextual/software.json");
 
-        ActionEntity createAction = new ActionEntity.ActionEntityBuilder(ActionTypeEnum.CREATE)
+        ActionEntity createAction = new ActionEntity.ActionEntityBuilder(ActionType.CREATE)
                 .setId("#Photo_Capture_1")
                 .setAgent("https://orcid.org/0000-0002-3545-944X")
                 .setDescription("Photo snapped on a photo walk on a misty day")
@@ -71,14 +71,14 @@ class ActionEntityTest {
     
     @Test
     void testAddUpdateAction() throws IOException {
-        ActionEntity createAction = new ActionEntity.ActionEntityBuilder(ActionTypeEnum.UPDATE)
+        ActionEntity createAction = new ActionEntity.ActionEntityBuilder(ActionType.UPDATE)
                 .setId("#history-02")
                 .setName("RO-Crate published")
                 .addObject("https://doi.org/10.5281/zenodo.1009240")
                 .setAgent("https://orcid.org/0000-0001-5152-5307")
                 .setEndTime("2018-09-10")
                 .addInstrument("https://stash.research.uts.edu.au")
-                .addIdProperty("actionStatus", "http://schema.org/CompletedActionStatus")
+                .setStatus(ActionStatus.COMPLETED_ACTION_STATUS)
                 .build();
         assertNotNull(createAction);
         HelpFunctions.compareEntityWithFile(createAction, "/json/entities/contextual/updateAction.json");

--- a/src/test/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntityTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntityTest.java
@@ -1,51 +1,46 @@
 package edu.kit.datamanager.ro_crate.entities.contextual;
 
 import edu.kit.datamanager.ro_crate.HelpFunctions;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 
 /**
  *
  * @author sabrinechelbi
  */
-public class ActionEntityTest {
+class ActionEntityTest {
 
     @Test
     void testAddCreateActionMinimalExample() throws IOException {
         
-        String idEquipment = "https://confluence.csiro.au/display/ASL/Hovermap";
         ContextualEntity equipment = new ContextualEntity.ContextualEntityBuilder()
-                .setId(idEquipment)
+                .setId("https://confluence.csiro.au/display/ASL/Hovermap")
                 .addType("IndividualProduct")
                 .addProperty("description", "The CSIRO bentwing is an unmanned aerial vehicle (UAV, commonly known as a drone) with a LIDAR ... ")
                 .addProperty("name", "Bentwing")
                 .addIdProperty("manufacturer", "https://www.atlassian.com/software/confluence")
                 .addProperty("serialNumber", "1111122233321231")
                 .build();
-        HelpFunctions.compareEntityWithFile(equipment, "/json/entities/contextual/equipment.json");
         
+        assertNotNull(equipment);
+        HelpFunctions.compareEntityWithFile(equipment, "/json/entities/contextual/equipment.json");
 
-        String idAction = "#DataCapture_wcc02";
-        List<String> instrument = new ArrayList<>();
-        instrument.add("https://confluence.csiro.au/display/ASL/Hovermap");
-        List<String> object = new ArrayList<>();
-        object.add("#victoria_arch");
-        List<String> result = new ArrayList<>();
-        result.add("wcc02_arch.laz");
-        result.add("wcc02_arch_traj.txt");
-        ActionEntity createAction = new ActionEntity.ActionEntityBuilder()
-                .setId(idAction)
-                .addType(ActionTypeEnum.CREATE)
-                .addAgent("https://orcid.org/0000-0002-1672-552X")
-                .addInstrument(instrument)
-                .addObject(object)
-                .addResult(result)
+        ActionEntity createAction = new ActionEntity.ActionEntityBuilder(ActionTypeEnum.CREATE)
+                .setId("#DataCapture_wcc02")
+                .setAgent("https://orcid.org/0000-0002-1672-552X")
+                .addInstrument("https://confluence.csiro.au/display/ASL/Hovermap")
+                .addObject("#victoria_arch")
+                // note how we can add multiple items by simply repeating them.
+                .addResult("wcc02_arch.laz")
+                .addResult("wcc02_arch_traj.txt")
                 .addDateTimeProperty("startTime","2017-06-10T12:56:14+10:00")
                 .addDateTimeProperty("endTime","2017-06-11T12:56:14+10:00")
                 .build();
-                
+        
+        assertNotNull(createAction);
         HelpFunctions.compareEntityWithFile(createAction, "/json/entities/contextual/createActionExample.json");
     }
     
@@ -62,40 +57,27 @@ public class ActionEntityTest {
                 .build();
         HelpFunctions.compareEntityWithFile(software, "/json/entities/contextual/software.json");
 
-        String id = "#Photo_Capture_1";
-        List<String> instrument = new ArrayList<>();
-        instrument.add("#EPL1");
-        instrument.add("#Panny20mm");
-        List<String> result = new ArrayList<>();
-        result.add("pics/2017-06-11%2012.56.14.jpg");
-        ActionEntity createAction = new ActionEntity.ActionEntityBuilder()
-                .setId(id)
-                .addType(ActionTypeEnum.CREATE)
-                .addAgent("https://orcid.org/0000-0002-3545-944X")
-                .addDescription("Photo snapped on a photo walk on a misty day")
-                .addEndTime("2017-06-11T12:56:14+10:00")
-                .addInstrument(instrument)
-                .addResult(result)
+        ActionEntity createAction = new ActionEntity.ActionEntityBuilder(ActionTypeEnum.CREATE)
+                .setId("#Photo_Capture_1")
+                .setAgent("https://orcid.org/0000-0002-3545-944X")
+                .setDescription("Photo snapped on a photo walk on a misty day")
+                .setEndTime("2017-06-11T12:56:14+10:00")
+                .addInstrument("#EPL1")
+                .addInstrument("#Panny20mm")
+                .addResult("pics/2017-06-11%2012.56.14.jpg")
                 .build();
         HelpFunctions.compareEntityWithFile(createAction, "/json/entities/contextual/createActionExampleSoftware.json");
     }
     
     @Test
     void testAddUpdateAction() throws IOException {
-
-        String id = "#history-02";
-        List<String> instrument = new ArrayList<>();
-        instrument.add("https://stash.research.uts.edu.au");
-         List<String> object = new ArrayList<>();
-        object.add("https://doi.org/10.5281/zenodo.1009240");
-        ActionEntity createAction = new ActionEntity.ActionEntityBuilder()
-                .setId(id)
-                .addType(ActionTypeEnum.UPDATE)
-                .addObject(object)
-                .addName("RO-Crate published")
-                .addAgent("https://orcid.org/0000-0001-5152-5307")
-                .addEndTime("2018-09-10")
-                .addInstrument(instrument)
+        ActionEntity createAction = new ActionEntity.ActionEntityBuilder(ActionTypeEnum.UPDATE)
+                .setId("#history-02")
+                .setName("RO-Crate published")
+                .addObject("https://doi.org/10.5281/zenodo.1009240")
+                .setAgent("https://orcid.org/0000-0001-5152-5307")
+                .setEndTime("2018-09-10")
+                .addInstrument("https://stash.research.uts.edu.au")
                 .addIdProperty("actionStatus", "http://schema.org/CompletedActionStatus")
                 .build();
         HelpFunctions.compareEntityWithFile(createAction, "/json/entities/contextual/updateAction.json");

--- a/src/test/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntityTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntityTest.java
@@ -46,15 +46,14 @@ class ActionEntityTest {
     
     @Test
     void testAddCreateActionUsingSoftware() throws IOException {
-        
-         String idSoftware = "https://www.imagemagick.org/";
         ContextualEntity software = new ContextualEntity.ContextualEntityBuilder()
-                .setId(idSoftware)
+                .setId("https://www.imagemagick.org/")
                 .addType("SoftwareApplication")
                 .addProperty("url", "https://www.imagemagick.org/")
                 .addProperty("name", "ImageMagick")
                 .addProperty("version", "ImageMagick 6.9.7-4 Q16 x86_64 20170114 http://www.imagemagick.org")
                 .build();
+        assertNotNull(software);
         HelpFunctions.compareEntityWithFile(software, "/json/entities/contextual/software.json");
 
         ActionEntity createAction = new ActionEntity.ActionEntityBuilder(ActionTypeEnum.CREATE)
@@ -66,6 +65,7 @@ class ActionEntityTest {
                 .addInstrument("#Panny20mm")
                 .addResult("pics/2017-06-11%2012.56.14.jpg")
                 .build();
+        assertNotNull(createAction);
         HelpFunctions.compareEntityWithFile(createAction, "/json/entities/contextual/createActionExampleSoftware.json");
     }
     
@@ -80,6 +80,7 @@ class ActionEntityTest {
                 .addInstrument("https://stash.research.uts.edu.au")
                 .addIdProperty("actionStatus", "http://schema.org/CompletedActionStatus")
                 .build();
+        assertNotNull(createAction);
         HelpFunctions.compareEntityWithFile(createAction, "/json/entities/contextual/updateAction.json");
     }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntityTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/entities/contextual/ActionEntityTest.java
@@ -36,8 +36,8 @@ class ActionEntityTest {
                 // note how we can add multiple items by simply repeating them.
                 .addResult("wcc02_arch.laz")
                 .addResult("wcc02_arch_traj.txt")
-                .addDateTimeProperty("startTime","2017-06-10T12:56:14+10:00")
-                .addDateTimeProperty("endTime","2017-06-11T12:56:14+10:00")
+                .setStartTime("2017-06-10T12:56:14+10:00")
+                .setEndTime("2017-06-11T12:56:14+10:00")
                 .build();
         
         assertNotNull(createAction);


### PR DESCRIPTION
- [x] make type mandatory
- [x] differentiate between add and set
- [x] provide convenience methods to add a single item multiple times so we can avoid creating lists all the time
- [x] consider using a set instead of a list to avoid duplicates?
- [x] Javadocs to explain that some methods append a single item to the list/set
- [x] make private attributes protected
- [x] fix linter hints in affected files
- [x] fix test coverage

---

As I am at this section anyway, let's do a small [spec](https://www.researchobject.org/ro-crate/specification/1.1/provenance.html#digital-library-and-repository-content) check:

- [x] Check if we support this: https://www.researchobject.org/ro-crate/specification/1.1/provenance.html#digital-library-and-repository-content
  - Should work, but we do not have a convenience class or builder for all of it.
- [x] check attribute enforcement
  - [x] "Actions MAY have human-readable names, which MAY be machine generated for use at scale."
  - [x] ~~"A curation Action MUST have at least one [object](http://schema.org/object) which associates it with either the root data entity Dataset or one of its components."~~(The spec examples violate this, so we do not enforce it in a hard way)
  - [x] "An Action SHOULD have a [name](http://schema.org/name) and MAY have a [description](http://schema.org/description)."
  - [x] "An Action SHOULD have an [endTime](http://schema.org/endTime), which MUST be in [ISO 8601 date format](http://schema.org/DateTime) and SHOULD be specified to at least the precision of a day."
  - [x] "An Action MAY have a [startTime](http://schema.org/startTime) meeting the same specifications."
  - [x] "An Action SHOULD have a human [agent](http://schema.org/agent) who was responsible for authorizing the action, and MAY have an [instrument](http://schema.org/instrument) which associates the action with a particular piece of software (for example, the content management system or data catalogue through which an update was approved) which SHOULD be of @type SoftwareApplication."
  - [x] "An Action’s status MAY be recorded in an [actionStatus](http://schema.org/actionStatus) property. The status must be one of the values enumerated by [ActionStatusType](http://schema.org/ActionStatusType): [ActiveActionStatus](http://schema.org/ActiveActionStatus), [CompletedActionStatus](http://schema.org/CompletedActionStatus), [FailedActionStatus](http://schema.org/FailedActionStatus) or [PotentialActionStatus](http://schema.org/PotentialActionStatus)."
  - [x] "An Action which has failed MAY record any error information in an [error](http://schema.org/error) property."
  - [x] "To record curation actions which modify a [File](http://schema.org/MediaObject) within a Dataset - for example, by correcting or enhancing metadata - the old version of the [File](http://schema.org/MediaObject) SHOULD be retained, and a [CreateAction](http://schema.org/CreateAction) added which has the original version as its [object](http://schema.org/object) and the new version as its [result](http://schema.org/result)." (Not sure if we can support this somehow in the API or give a warning triggered by indicators?)