### PR TITLE
Avoid adding dataEntities which are not being added to the root data entity

### DIFF
--- a/src/main/java/edu/kit/datamanager/ro_crate/Crate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/Crate.java
@@ -71,7 +71,12 @@ public interface Crate {
 
   AbstractEntity getEntityById(java.lang.String id);
 
-  void addDataEntity(DataEntity entity, Boolean toHasPart);
+  /**
+   * Adds a data entity to the crate.
+   *
+   * @param entity the DataEntity to add to this crate.
+   */
+  void addDataEntity(DataEntity entity);
 
   void addContextualEntity(ContextualEntity entity);
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/Crate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/Crate.java
@@ -24,7 +24,7 @@ public interface Crate {
   /**
    * Read version from the crate descriptor and return it as a class
    * representation.
-   * 
+   * <p>
    * NOTE: If there is no version in the crate, it does not comply with the
    * specification.
    * 
@@ -36,9 +36,9 @@ public interface Crate {
   /**
    * Returns strings indicating the conformance of a crate with other
    * specifications than the RO-Crate version.
-   * 
+   * <p>
    * If you need the crate version too, refer to {@link #getVersion()}.
-   * 
+   * <p>
    * This corresponds technically to all conformsTo values, excluding the RO crate
    * version / specification.
    * 

--- a/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
@@ -40,13 +40,13 @@ import java.util.stream.StreamSupport;
  */
 public class RoCrate implements Crate {
 
-    private final CratePayload roCratePayload;
-    private CrateMetadataContext metadataContext;
-    private CratePreview roCratePreview;
-    private RootDataEntity rootDataEntity;
-    private ContextualEntity jsonDescriptor;
+    protected final CratePayload roCratePayload;
+    protected CrateMetadataContext metadataContext;
+    protected CratePreview roCratePreview;
+    protected RootDataEntity rootDataEntity;
+    protected ContextualEntity jsonDescriptor;
 
-    private Collection<File> untrackedFiles;
+    protected Collection<File> untrackedFiles;
 
     @Override
     public CratePreview getPreview() {

--- a/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
@@ -30,7 +30,7 @@ import java.util.stream.StreamSupport;
 
 /**
  * The class that represents a single ROCrate.
- *
+ * <p>
  * To build or modify it, use a instance of {@link RoCrateBuilder}. In the case
  * features of RO-Crate DRAFT specifications are needed, refer to
  * {@link BuilderWithDraftFeatures} and its documentation.
@@ -422,7 +422,7 @@ public class RoCrate implements Crate {
         }
 
         /**
-         * Returns a crate with the information from this builder.
+         * @return a crate with the information from this builder.
          */
         public RoCrate build() {
             return new RoCrate(this);
@@ -432,9 +432,9 @@ public class RoCrate implements Crate {
     /**
      * Builder for Crates, supporting features which are not in a final
      * specification yet.
-     *
+     * <p>
      * NOTE: This will change the specification version of your crate.
-     *
+     * <p>
      * We only add features we expect to be in the new specification in the end.
      * In case a feature will not make it into the specification, we will mark
      * it as deprecated and remove it in new major versions. If a feature is
@@ -475,7 +475,7 @@ public class RoCrate implements Crate {
         /**
          * Indicate this crate also conforms to the given specification, in
          * addition to the version this builder adds.
-         *
+         * <p>
          * This is helpful for profiles or other specifications the crate
          * conforms to. Can be called multiple times to add more specifications.
          *

--- a/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
@@ -181,13 +181,19 @@ public class RoCrate implements Crate {
         return this.roCratePayload.getEntityById(id);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Note: This will also link the DataEntity to the root node
+     * using the root nodes hasPart property.
+     *
+     * @param entity the DataEntity to add to this crate.
+     */
     @Override
-    public void addDataEntity(DataEntity entity, Boolean toHasPart) {
+    public void addDataEntity(DataEntity entity) {
         this.metadataContext.checkEntity(entity);
         this.roCratePayload.addDataEntity(entity);
-        if (Boolean.TRUE.equals(toHasPart)) {
-            this.rootDataEntity.addToHasPart(entity.getId());
-        }
+        this.rootDataEntity.addToHasPart(entity.getId());
     }
 
     @Override
@@ -327,10 +333,12 @@ public class RoCrate implements Crate {
         }
 
         /**
-         * Adding a data entity to the crate. The important part here is to also
-         * add its id to the RootData Entity hasPart.
+         * Adds a data entity to the crate.
+         * <p>
+         * Note: This will also link the DataEntity to the root node
+         * using the root nodes hasPart property.
          *
-         * @param dataEntity the DataEntity object.
+         * @param dataEntity the DataEntity to add to this crate.
          * @return returns the builder for further usage.
          */
         public RoCrateBuilder addDataEntity(DataEntity dataEntity) {

--- a/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/dataentities/ImportFromZenodo.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/dataentities/ImportFromZenodo.java
@@ -113,7 +113,7 @@ public class ImportFromZenodo {
         if (entity.get("@id").asText().equals(mainId)) {
           var dataEntity = new DataEntity.DataEntityBuilder()
               .setAll((ObjectNode) entity).build();
-          crate.addDataEntity(dataEntity, true);
+          crate.addDataEntity(dataEntity);
         } else {
           // here we have to think of a way to differentiate between data and contextual entities.
           var contextualEntity = new ContextualEntity.ContextualEntityBuilder()

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/RoCrateReader.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/RoCrateReader.java
@@ -32,6 +32,19 @@ import java.util.stream.StreamSupport;
 public class RoCrateReader {
 
   /**
+   * This is a private inner class that shall not be exposed.
+   * **Do not make it public or protected.** It serves only the
+   * purpose of unsafe operations while reading a crate and
+   * may be specific to this implementation.
+   */
+  private static class RoCrateUnsafe extends RoCrate {
+    public void addDataEntityWithoutRootHasPart(DataEntity entity) {
+      this.metadataContext.checkEntity(entity);
+      this.roCratePayload.addDataEntity(entity);
+    }
+  }
+
+  /**
    * If the number of JSON entities in the crate is larger than this number,
    * parallelization will be used.
    */
@@ -78,7 +91,7 @@ public class RoCrateReader {
     JsonNode context = metadataJson.get(PROP_CONTEXT);
     
     CrateMetadataContext crateContext = new RoCrateMetadataContext(context);
-    RoCrate crate = new RoCrate();
+    RoCrateUnsafe crate = new RoCrateUnsafe();
     crate.setMetadataContext(crateContext);
     JsonNode graph = metadataJson.get(PROP_GRAPH);
 
@@ -101,7 +114,7 @@ public class RoCrateReader {
                       .setId(file.getName());
             });
 
-            crate.addDataEntity(dataEntity.build());
+            crate.addDataEntityWithoutRootHasPart(dataEntity.build());
           } else {
             // contextual entity
             crate.addContextualEntity(

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/RoCrateReader.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/RoCrateReader.java
@@ -103,7 +103,7 @@ public class RoCrateReader {
                 .setId(loc.getName());
           }
 
-          crate.addDataEntity(dataEntity.build(), false);
+          crate.addDataEntity(dataEntity.build());
         } else {
           // contextual entity
           crate.addContextualEntity(

--- a/src/main/java/edu/kit/datamanager/ro_crate/special/IdentifierUtils.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/special/IdentifierUtils.java
@@ -16,7 +16,7 @@ import java.net.URISyntaxException;
 /**
  * This class defines methods regarding URIs in general, which in RO-Crate
  * context means usually a valid, resolvable URL or a relative file path.
- *
+ * <p>
  * The purpose is to have a simple abstraction where the way e.g. a URL is
  * checked can be changed and tested easily for the whole library.
  */
@@ -28,7 +28,7 @@ public class IdentifierUtils {
     /**
      * Returns true, if the given String is encoded and can be used as an
      * identifier in RO-Crate.
-     * 
+     * <p>
      * Possible identifiers include:
      * - a uri
      * - a url
@@ -50,7 +50,9 @@ public class IdentifierUtils {
      */
     public static boolean isUrl(String uri) {
         try {
-            return asUrl(encode(uri).get()).isPresent();
+            return encode(uri)
+                    .map(decodedUri -> asUrl(decodedUri).isPresent())
+                    .orElse(false);
         } catch (Exception e) {
             return false;
         }

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/ReadAndWriteTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/ReadAndWriteTest.java
@@ -20,7 +20,7 @@ import java.nio.file.Path;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
-public class ReadAndWriteTest {
+class ReadAndWriteTest {
 
   @Test
   void testReadingAndWriting(@TempDir Path path) throws IOException {
@@ -46,5 +46,13 @@ public class ReadAndWriteTest {
     assertEquals(0, newCrate.getUntrackedFiles().size());
 
     HelpFunctions.compareTwoCrateJson(newCrate, crate);
+  }
+
+  @Test
+  void testReadCrateWithHasPartHierarchy() {
+    RoCrateReader reader = new RoCrateReader(new FolderReader());
+    RoCrate crate = reader.readCrate(ReadAndWriteTest.class.getResource("/crates/hasPartHierarchy").getPath());
+    assertEquals(1, crate.getAllContextualEntities().size());
+    assertEquals(4, crate.getAllDataEntities().size());
   }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/realexamples/RealTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/realexamples/RealTest.java
@@ -44,8 +44,7 @@ class RealTest {
                         .setLocationWithExceptions(newFile.toAbsolutePath())
                         .setId("new_file.txt")
                         .addProperty("description", "my new file that I added")
-                        .build(),
-                true);
+                        .build());
 
         PersonEntity person = OrcidProvider.getPerson("https://orcid.org/0000-0001-9842-9718");
         crate.addContextualEntity(person);

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/FolderReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/FolderReaderTest.java
@@ -216,7 +216,7 @@ class FolderReaderTest {
         .setEncodingFormat("setnew")
         .setLocationWithExceptions(newFile)
         .setId("new_file")
-        .build(), true);
+        .build());
 
     Path destinationDir = temp.resolve("result");
     FileUtils.forceMkdir(destinationDir.toFile());

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipReaderTest.java
@@ -149,7 +149,7 @@ class ZipReaderTest {
         .setEncodingFormat("setnew")
         .setLocationWithExceptions(newFile)
         .setId("new_file")
-        .build(), true);
+        .build());
 
     Path destinationDir = temp.resolve("result");
     FileUtils.forceMkdir(destinationDir.toFile());

--- a/src/test/resources/crates/hasPartHierarchy/ro-crate-metadata.json
+++ b/src/test/resources/crates/hasPartHierarchy/ro-crate-metadata.json
@@ -1,0 +1,53 @@
+{
+    "@context": "https://w3id.org/ro/crate/1.1/context",
+    "@graph": [
+        {
+            "@type": "CreativeWork",
+            "@id": "ro-crate-metadata.json",
+            "conformsTo": {
+                "@id": "https://w3id.org/ro/crate/1.1"
+            },
+            "about": {
+                "@id": "./"
+            }
+        },
+        {
+            "@id": "./",
+            "@type": "Dataset",
+            "name": "Root element",
+            "description": "Description",
+            "license": {
+                "@id": "https://creativecommons.org/licenses/by-nc-sa/3.0/au/"
+            },
+            "hasPart": [
+                {"@id": "sub-a.file"},
+                {"@id": "sub-b.file"}
+            ]
+        },
+        {
+            "@id": "https://creativecommons.org/licenses/by-nc-sa/3.0/au/",
+            "@type": "CreativeWork",
+            "description": "Contextual entity (license)",
+            "identifier": "https://creativecommons.org/licenses/by-nc-sa/3.0/au/",
+            "name": "Attribution-NonCommercial-ShareAlike 3.0 Australia (CC BY-NC-SA 3.0 AU)"
+        },
+        {
+            "@id": "sub-a.file",
+            "@type": "File"
+        },
+        {
+            "@id": "sub-b.file",
+            "@type": "File",
+            "hasPart": {"@id": "sub-b-sub-a.file"}
+        },
+        {
+            "@id": "sub-b-sub-a.file",
+            "@type": "File"
+        },
+        {
+            "@id": "sub-b-sub-b.file",
+            "@type": "File",
+            "isPartOf": { "@id": "sub-b.file" }
+        }
+    ]
+}


### PR DESCRIPTION
- [x] make it impossible to do this (as it is currently not intended)
- [x] Linter fixes
- [x] It is not really required to have a DIRECT connection to the root data entity. This means we can currently confuse DataEntities for ContextEntities. From the specification, I can not derive a perfect way to handle this, though. Should we "fix" it?
  - "Data Entities can also be other types, for instance an online database. These SHOULD be of "@type": "CreativeWork" and typically have a @id which is an absolute URI." --> This is not enough to make a reliable assumption on the type. We need to check "indirect" relations to root somehow.
  - --> Implemented traversal of hasPart and isPartOf from root downwards. Should work.
- [x] Test this with a hypothetic crate or a real example
- [x] Make code clean enough

**Will not fix:**

- Adding a DataEntity will add it to root implicitly, and we currently do not have an API not to do this and only connect it indirectly to root. At least we recognize such elements as root now, but if we create it today, root will always point to all DataEntities. Which is, I believe, not too bad.