### PR TITLE
fix: RootDataEntity identifier is not allowed for other entities.

### DIFF
--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import edu.kit.datamanager.ro_crate.entities.data.RootDataEntity;
 import edu.kit.datamanager.ro_crate.entities.serializers.ObjectNodeSerializer;
 import edu.kit.datamanager.ro_crate.entities.validation.EntityValidation;
 import edu.kit.datamanager.ro_crate.entities.validation.JsonSchemaValidation;
@@ -363,7 +364,7 @@ public class AbstractEntity {
          * @return the generic builder.
          */
         public T setId(String id) {
-            if (id != null) {
+            if (id != null && !id.equals(RootDataEntity.ID)) {
                 if (IdentifierUtils.isValidUri(id)) {
                     this.id = id;
                 } else {

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/data/RootDataEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/data/RootDataEntity.java
@@ -9,7 +9,7 @@ import java.nio.file.Paths;
  */
 public class RootDataEntity extends DataSetEntity {
 
-  private static final String ID = "./";
+  public static final String ID = "./";
 
   public RootDataEntity(AbstractDataSetBuilder<?> entityBuilder) {
     super(entityBuilder);

--- a/src/test/java/edu/kit/datamanager/ro_crate/entities/data/DataSetEntityTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/entities/data/DataSetEntityTest.java
@@ -2,8 +2,6 @@ package edu.kit.datamanager.ro_crate.entities.data;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
@@ -11,15 +9,28 @@ import edu.kit.datamanager.ro_crate.HelpFunctions;
 import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
 import java.net.URI;
 import java.nio.file.Paths;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.util.Objects;
 
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Nikola Tzotchev on 5.2.2022 г.
  * @version 1
  */
 public class DataSetEntityTest {
+
+    @Test
+    void testImpossibleRootId() {
+        DataSetEntity e = new DataSetEntity.DataSetBuilder()
+                .setId("./")
+                .addProperty("not_root", true)
+                .build();
+        assertNotNull(e.getId());
+        assertFalse(e.getId().isBlank());
+        assertNotEquals(RootDataEntity.ID, e.getId());
+    }
 
     @Test
     void testSimpleDirDeserialization() throws IOException {


### PR DESCRIPTION
We handle it the same as "null". Which means an ID will not be set and instead one will be generated.

Closes #48 