### PR TITLE
Fix invalid context check warnings

### DIFF
--- a/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
@@ -122,7 +122,7 @@ public class RoCrateMetadataContext implements CrateMetadataContext {
       if (s.equals("@id")) {
         // @id will refer to the value of the id of the node
         // so we need to extract this value
-        s = node.path(s).asText(s);
+        s = entity.getId();
       }
       if (s.equals("@json")) {
         // A linked data builtin type, which is fine.

--- a/src/main/java/edu/kit/datamanager/ro_crate/special/IdentifierUtils.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/special/IdentifierUtils.java
@@ -51,7 +51,7 @@ public class IdentifierUtils {
     public static boolean isUrl(String uri) {
         try {
             return encode(uri)
-                    .map(decodedUri -> asUrl(decodedUri).isPresent())
+                    .map(encodedUri -> asUrl(encodedUri).isPresent())
                     .orElse(false);
         } catch (Exception e) {
             return false;

--- a/src/test/java/edu/kit/datamanager/ro_crate/context/ContextTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/context/ContextTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import edu.kit.datamanager.ro_crate.HelpFunctions;
+import edu.kit.datamanager.ro_crate.entities.AbstractEntity;
 import edu.kit.datamanager.ro_crate.entities.contextual.ContextualEntity;
 import edu.kit.datamanager.ro_crate.entities.data.DataEntity;
 import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
@@ -189,5 +190,38 @@ public class ContextTest {
         .build();
     // house is in the context
     assertTrue(newContext.checkEntity(data));
+  }
+
+  @Test
+  void testIdType() {
+    AbstractEntity validEntity = new DataEntity.DataEntityBuilder()
+            .setId("Airline")  // this is defined in the context!
+            .addType("@id")  // this is a JSON-LD feature to refer to the ID ("Airline") as a type
+            .addType("@json")  // this is a JSON-LD built-in type
+            .build();
+    assertTrue(this.context.checkEntity(validEntity));
+
+    AbstractEntity invalidEntity = new DataEntity.DataEntityBuilder()
+            .setId("Something which is definitely not in the context")
+            .addType("@id")
+            .build();
+    assertFalse(this.context.checkEntity(invalidEntity));
+  }
+
+  @Test
+  void testJsonType() {
+    AbstractEntity validEntity = new DataEntity.DataEntityBuilder()
+            .addType("@json")  // this is a JSON-LD built-in type
+            .build();
+    assertTrue(this.context.checkEntity(validEntity));
+  }
+
+  @Test
+  void testAbsoluteUrlType() {
+    AbstractEntity validEntity = new DataEntity.DataEntityBuilder()
+            .addType("http://example.org/Person")  // this is not in the context!
+            .addProperty("http://example.org/Thing", "Some thing")
+            .build();
+    assertTrue(this.context.checkEntity(validEntity));
   }
 }


### PR DESCRIPTION
- [x] Handle `@id` as type as if the id would be the type.
- [x] Consider `@json` to be a type which does not need context. Consider making a list in case we discover more such cases later on.
- [x] make sure something like `https://schema.org/Dataset` is handled properly as a type and not as a suffix of a type (see below). We might need some proper types abstraction for this.
- [x] tests missing