### PR TITLE
Fix `addEntities()` and `addFromCollection()` generic parameter

### DIFF
--- a/src/main/java/edu/kit/datamanager/ro_crate/Crate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/Crate.java
@@ -84,7 +84,7 @@ public interface Crate {
 
   void setUntrackedFiles(Collection<File> files);
 
-  void addFromCollection(Collection<AbstractEntity> entities);
+  void addFromCollection(Collection<? extends AbstractEntity> entities);
 
   void addItemFromDataCite(String locationUrl);
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
@@ -229,7 +229,7 @@ public class RoCrate implements Crate {
     }
 
     @Override
-    public void addFromCollection(Collection<AbstractEntity> entities) {
+    public void addFromCollection(Collection<? extends AbstractEntity> entities) {
         this.roCratePayload.addEntities(entities);
     }
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/payload/CratePayload.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/payload/CratePayload.java
@@ -30,7 +30,7 @@ public interface CratePayload {
 
   void addEntity(AbstractEntity entity);
 
-  void addEntities(Collection<AbstractEntity> entity);
+  void addEntities(Collection<? extends AbstractEntity> entity);
 
   Set<AbstractEntity> getAllEntities();
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/payload/RoCratePayload.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/payload/RoCratePayload.java
@@ -77,7 +77,7 @@ public class RoCratePayload implements CratePayload {
   }
 
   @Override
-  public void addEntities(Collection<AbstractEntity> entities) {
+  public void addEntities(Collection<? extends AbstractEntity> entities) {
     if (entities != null) {
       for (var element : entities) {
         this.addEntity(element);


### PR DESCRIPTION
Because of java type erasure on generics this code doesn't compile even though `DataEntity` inherits from `AbstractEntity`:
```
RoCrate crate = new RoCrate();
Collection<DataEntity> entities = new ArrayList<>();
crate.addFromCollection(entities);
```
This patch makes it possible to add a collection of `AbstractEntity` or any class that inherits from it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced how the system handles collections of entity types, now accommodating a wider variety of entity subtypes for increased flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->