### PR TITLE
Point to latest release in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and avoiding crates which do not fully comply to the specification, at the same 
 
 ## Use it in your application
 
-- [Instructions for your build manager (e.g., Gradle, Maven, etc.)](https://central.sonatype.com/artifact/edu.kit.datamanager/ro-crate-java/1.1.0)
+- [Instructions for your build manager (e.g., Gradle, Maven, etc.)](https://central.sonatype.com/artifact/edu.kit.datamanager/ro-crate-java)
 - [Quick-Start](#quick-start)
 - [Adapting Specification Examples](#adapting-the-specification-examples)
 - [Related Publications](https://publikationen.bibliothek.kit.edu/publikationslisten/get.php?referencing=all&external_publications=kit&lang=de&format=html&style=kit-3lines-title_b-authors-other&consider_suborganizations=true&order=desc%20year&contributors=%5B%5B%5B%5D%2C%5B%22p20751.105%22%5D%5D%5D&title_contains=crate)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the build manager instructions link to point to the main artifact page instead of a fixed version.
  - This change simplifies access by directing users to the latest build guidance, ensuring clarity and ease of use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->