### PR TITLE
Fix #241: Getting key value pairs from the context

### DIFF
--- a/src/main/java/edu/kit/datamanager/ro_crate/Crate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/Crate.java
@@ -57,19 +57,19 @@ public interface Crate {
    * @param key the key to be searched
    * @return the value of the key, null if not found
    */
-  String getMetadataContextValueOf(String key);
+  String readMetadataContextValueOf(String key);
 
   /**
    * Get an immutable collection of the keys in the metadata context.
    * @return the keys in the metadata context
    */
-  Set<String> getMetadataContextKeys();
+  Set<String> readMetadataContextKeys();
 
   /**
    * Get an immutable map of the context.
    * @return an immutable map containing the context key-value pairs
    */
-  Map<String, String> getMetadataContextPairs();
+  Map<String, String> readMetadataContextPairs();
 
   RootDataEntity getRootDataEntity();
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/Crate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/Crate.java
@@ -51,6 +51,13 @@ public interface Crate {
 
   void setMetadataContext(CrateMetadataContext metadataContext);
 
+  /**
+   * Get the value of a key from the metadata context.
+   * @param key the key to be searched
+   * @return the value of the key, null if not found
+   */
+  String getMetadataContextValueOf(String key);
+
   RootDataEntity getRootDataEntity();
 
   void setRootDataEntity(RootDataEntity rootDataEntity);

--- a/src/main/java/edu/kit/datamanager/ro_crate/Crate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/Crate.java
@@ -57,19 +57,19 @@ public interface Crate {
    * @param key the key to be searched
    * @return the value of the key, null if not found
    */
-  String readMetadataContextValueOf(String key);
+  String getMetadataContextValueOf(String key);
 
   /**
    * Get an immutable collection of the keys in the metadata context.
    * @return the keys in the metadata context
    */
-  Set<String> readMetadataContextKeys();
+  Set<String> getMetadataContextKeys();
 
   /**
    * Get an immutable map of the context.
    * @return an immutable map containing the context key-value pairs
    */
-  Map<String, String> readMetadataContextPairs();
+  Map<String, String> getMetadataContextPairs();
 
   RootDataEntity getRootDataEntity();
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/Crate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/Crate.java
@@ -2,6 +2,7 @@ package edu.kit.datamanager.ro_crate;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -57,6 +58,18 @@ public interface Crate {
    * @return the value of the key, null if not found
    */
   String getMetadataContextValueOf(String key);
+
+  /**
+   * Get an immutable collection of the keys in the metadata context.
+   * @return the keys in the metadata context
+   */
+  Set<String> getMetadataContextKeys();
+
+  /**
+   * Get an immutable map of the context.
+   * @return an immutable map containing the context key-value pairs
+   */
+  Map<String, String> getMetadataContextPairs();
 
   RootDataEntity getRootDataEntity();
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
@@ -62,18 +62,18 @@ public class RoCrate implements Crate {
         this.metadataContext = metadataContext;
     }
 
-    public String readMetadataContextValueOf(String key) {
-        return this.metadataContext.readValueOf(key);
+    public String getMetadataContextValueOf(String key) {
+        return this.metadataContext.getValueOf(key);
     }
 
     @Override
-    public Set<String> readMetadataContextKeys() {
-        return this.metadataContext.readKeys();
+    public Set<String> getMetadataContextKeys() {
+        return this.metadataContext.getKeys();
     }
 
     @Override
-    public Map<String, String> readMetadataContextPairs() {
-        return this.metadataContext.readPairs();
+    public Map<String, String> getMetadataContextPairs() {
+        return this.metadataContext.getPairs();
     }
 
     public ContextualEntity getJsonDescriptor() {

--- a/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
@@ -62,6 +62,10 @@ public class RoCrate implements Crate {
         this.metadataContext = metadataContext;
     }
 
+    public String getMetadataContextValueOf(String key) {
+        return this.metadataContext.getValueOf(key);
+    }
+
     public ContextualEntity getJsonDescriptor() {
         return jsonDescriptor;
     }

--- a/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
@@ -66,6 +66,16 @@ public class RoCrate implements Crate {
         return this.metadataContext.getValueOf(key);
     }
 
+    @Override
+    public Set<String> getMetadataContextKeys() {
+        return this.metadataContext.getImmutableKeys();
+    }
+
+    @Override
+    public Map<String, String> getMetadataContextPairs() {
+        return this.metadataContext.getImmutablePairs();
+    }
+
     public ContextualEntity getJsonDescriptor() {
         return jsonDescriptor;
     }

--- a/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
@@ -62,18 +62,18 @@ public class RoCrate implements Crate {
         this.metadataContext = metadataContext;
     }
 
-    public String getMetadataContextValueOf(String key) {
-        return this.metadataContext.getValueOf(key);
+    public String readMetadataContextValueOf(String key) {
+        return this.metadataContext.readValueOf(key);
     }
 
     @Override
-    public Set<String> getMetadataContextKeys() {
-        return this.metadataContext.getImmutableKeys();
+    public Set<String> readMetadataContextKeys() {
+        return this.metadataContext.readKeys();
     }
 
     @Override
-    public Map<String, String> getMetadataContextPairs() {
-        return this.metadataContext.getImmutablePairs();
+    public Map<String, String> readMetadataContextPairs() {
+        return this.metadataContext.readPairs();
     }
 
     public ContextualEntity getJsonDescriptor() {

--- a/src/main/java/edu/kit/datamanager/ro_crate/context/CrateMetadataContext.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/context/CrateMetadataContext.java
@@ -30,19 +30,19 @@ public interface CrateMetadataContext {
    * @param key the key to be searched
    * @return the value of the key, null if not found
    */
-  String getValueOf(String key);
+  String readValueOf(String key);
 
   /**
    * Get an immutable collection of the keys in the metadata context.
    * @return the keys in the metadata context
    */
-  Set<String> getImmutableKeys();
+  Set<String> readKeys();
 
   /**
   * Get an immutable map of the context.
   * @return an immutable map containing the context key-value pairs
   */
-  Map<String, String> getImmutablePairs();
+  Map<String, String> readPairs();
 
   void deleteValuePairFromContext(String key);
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/context/CrateMetadataContext.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/context/CrateMetadataContext.java
@@ -30,19 +30,19 @@ public interface CrateMetadataContext {
    * @param key the key to be searched
    * @return the value of the key, null if not found
    */
-  String readValueOf(String key);
+  String getValueOf(String key);
 
   /**
    * Get an immutable collection of the keys in the metadata context.
    * @return the keys in the metadata context
    */
-  Set<String> readKeys();
+  Set<String> getKeys();
 
   /**
   * Get an immutable map of the context.
   * @return an immutable map containing the context key-value pairs
   */
-  Map<String, String> readPairs();
+  Map<String, String> getPairs();
 
   void deleteValuePairFromContext(String key);
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/context/CrateMetadataContext.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/context/CrateMetadataContext.java
@@ -22,6 +22,13 @@ public interface CrateMetadataContext {
 
   void addToContext(String key, String value);
 
+  /**
+   * Get the value of a key from the context.
+   * @param key the key to be searched
+   * @return the value of the key, null if not found
+   */
+  String getValueOf(String key);
+
   void deleteValuePairFromContext(String key);
 
   void deleteUrlFromContext(String url);

--- a/src/main/java/edu/kit/datamanager/ro_crate/context/CrateMetadataContext.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/context/CrateMetadataContext.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import edu.kit.datamanager.ro_crate.entities.AbstractEntity;
 
+import java.util.Map;
+import java.util.Set;
+
 /**
  * Interface for the metadata context.
  * Most often in an ROCrate this is the default context,
@@ -28,6 +31,18 @@ public interface CrateMetadataContext {
    * @return the value of the key, null if not found
    */
   String getValueOf(String key);
+
+  /**
+   * Get an immutable collection of the keys in the metadata context.
+   * @return the keys in the metadata context
+   */
+  Set<String> getImmutableKeys();
+
+  /**
+  * Get an immutable map of the context.
+  * @return an immutable map containing the context key-value pairs
+  */
+  Map<String, String> getImmutablePairs();
 
   void deleteValuePairFromContext(String key);
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
@@ -201,6 +201,12 @@ public class RoCrateMetadataContext implements CrateMetadataContext {
   }
 
   @Override
+  public String getValueOf(String key) {
+    return Optional.ofNullable(this.contextMap.get(key))
+            .orElseGet(() -> this.other.get(key));
+  }
+
+  @Override
   public void deleteValuePairFromContext(String key) {
     this.contextMap.remove(key);
     this.other.remove(key);

--- a/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
@@ -207,6 +207,23 @@ public class RoCrateMetadataContext implements CrateMetadataContext {
   }
 
   @Override
+  public Set<String> getImmutableKeys() {
+    List<String> merged = new ArrayList<>();
+    merged.addAll(this.contextMap.keySet());
+    merged.addAll(this.other.keySet());
+    return Set.copyOf(merged);
+  }
+
+  @Override
+  public Map<String, String> getImmutablePairs() {
+    Map<String, String> merged = new HashMap<>();
+    merged.putAll(this.contextMap);
+    merged.putAll(this.other);
+    return Map.copyOf(merged);
+  }
+
+
+  @Override
   public void deleteValuePairFromContext(String key) {
     this.contextMap.remove(key);
     this.other.remove(key);

--- a/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
@@ -31,7 +31,7 @@ public class RoCrateMetadataContext implements CrateMetadataContext {
   protected static final String DEFAULT_CONTEXT_LOCATION = "default_context/version1.1.json";
   protected static JsonNode defaultContext = null;
 
-  protected final Set<String> url = new HashSet<>();
+  protected final Set<String> urls = new HashSet<>();
   protected final HashMap<String, String> contextMap = new HashMap<>();
   // we need to keep the ones that are no coming from url
   // for the final representation
@@ -89,7 +89,7 @@ public class RoCrateMetadataContext implements CrateMetadataContext {
     ArrayNode array = objectMapper.createArrayNode();
     ObjectNode jsonNode = objectMapper.createObjectNode();
     ObjectNode finalNode = objectMapper.createObjectNode();
-    for (String e : url) {
+    for (String e : urls) {
       array.add(e);
     }
     for (Map.Entry<String, String> s : other.entrySet()) {
@@ -156,7 +156,7 @@ public class RoCrateMetadataContext implements CrateMetadataContext {
 
   @Override
   public void addToContextFromUrl(String url) {
-    this.url.add(url);
+    this.urls.add(url);
 
     ObjectMapper objectMapper = MyObjectMapper.getMapper();
 
@@ -208,7 +208,7 @@ public class RoCrateMetadataContext implements CrateMetadataContext {
 
   @Override
   public void deleteUrlFromContext(String url) {
-    this.url.remove(url);
+    this.urls.remove(url);
   }
 
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
@@ -201,13 +201,13 @@ public class RoCrateMetadataContext implements CrateMetadataContext {
   }
 
   @Override
-  public String getValueOf(String key) {
+  public String readValueOf(String key) {
     return Optional.ofNullable(this.contextMap.get(key))
             .orElseGet(() -> this.other.get(key));
   }
 
   @Override
-  public Set<String> getImmutableKeys() {
+  public Set<String> readKeys() {
     List<String> merged = new ArrayList<>();
     merged.addAll(this.contextMap.keySet());
     merged.addAll(this.other.keySet());
@@ -215,7 +215,7 @@ public class RoCrateMetadataContext implements CrateMetadataContext {
   }
 
   @Override
-  public Map<String, String> getImmutablePairs() {
+  public Map<String, String> readPairs() {
     Map<String, String> merged = new HashMap<>();
     merged.putAll(this.contextMap);
     merged.putAll(this.other);

--- a/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
@@ -201,13 +201,13 @@ public class RoCrateMetadataContext implements CrateMetadataContext {
   }
 
   @Override
-  public String readValueOf(String key) {
+  public String getValueOf(String key) {
     return Optional.ofNullable(this.contextMap.get(key))
             .orElseGet(() -> this.other.get(key));
   }
 
   @Override
-  public Set<String> readKeys() {
+  public Set<String> getKeys() {
     List<String> merged = new ArrayList<>();
     merged.addAll(this.contextMap.keySet());
     merged.addAll(this.other.keySet());
@@ -215,7 +215,7 @@ public class RoCrateMetadataContext implements CrateMetadataContext {
   }
 
   @Override
-  public Map<String, String> readPairs() {
+  public Map<String, String> getPairs() {
     Map<String, String> merged = new HashMap<>();
     merged.putAll(this.contextMap);
     merged.putAll(this.other);

--- a/src/test/java/edu/kit/datamanager/ro_crate/context/ContextTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/context/ContextTest.java
@@ -238,26 +238,26 @@ public class ContextTest {
     String key = "key";
     String value = "value";
     context.addToContext(key, value);
-    assertEquals(value, context.readValueOf(key));
+    assertEquals(value, context.getValueOf(key));
     context.deleteValuePairFromContext(key);
-    assertNull(context.readValueOf(key));
+    assertNull(context.getValueOf(key));
   }
 
   @Test
   void testReadDeleteGetPair() {
     String key = "custom";
     String value = "_:";
-    assertEquals(value, this.complexContext.readValueOf(key));
+    assertEquals(value, this.complexContext.getValueOf(key));
     this.complexContext.deleteValuePairFromContext(key);
-    assertNull(this.complexContext.readValueOf(key));
+    assertNull(this.complexContext.getValueOf(key));
     this.complexContext.addToContext(key, value);
-    assertEquals(value, this.complexContext.readValueOf(key));
+    assertEquals(value, this.complexContext.getValueOf(key));
   }
 
   @Test
   void testReadKeys() {
     var expected = Set.of("custom", "owl", "datacite", "xsd", "rdfs");
-    var given = this.complexContext.readKeys();
+    var given = this.complexContext.getKeys();
     for (String key : expected) {
       assertTrue(given.contains(key), "Key " + key + " not found in the context");
     }
@@ -268,7 +268,7 @@ public class ContextTest {
   @Test
   void testReadPairs() {
     var expected = Set.of("custom", "owl", "datacite", "xsd", "rdfs");
-    var given = this.complexContext.readPairs();
+    var given = this.complexContext.getPairs();
     var keys = given.keySet();
     var values = given.values();
     for (String key : expected) {

--- a/src/test/java/edu/kit/datamanager/ro_crate/context/ContextTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/context/ContextTest.java
@@ -233,9 +233,9 @@ public class ContextTest {
     String key = "key";
     String value = "value";
     context.addToContext(key, value);
-    assertEquals(value, context.getValueOf(key));
+    assertEquals(value, context.readValueOf(key));
     context.deleteValuePairFromContext(key);
-    assertNull(context.getValueOf(key));
+    assertNull(context.readValueOf(key));
   }
 
   @Test
@@ -243,18 +243,18 @@ public class ContextTest {
     setupComplexContext();
     String key = "custom";
     String value = "_:";
-    assertEquals(value, context.getValueOf(key));
+    assertEquals(value, context.readValueOf(key));
     context.deleteValuePairFromContext(key);
-    assertNull(context.getValueOf(key));
+    assertNull(context.readValueOf(key));
     context.addToContext(key, value);
-    assertEquals(value, context.getValueOf(key));
+    assertEquals(value, context.readValueOf(key));
   }
 
   @Test
   void testReadKeys() throws IOException {
     setupComplexContext();
     var expected = Set.of("custom", "owl", "datacite", "xsd", "rdfs");
-    var given = context.getImmutableKeys();
+    var given = context.readKeys();
     for (String key : expected) {
       assertTrue(given.contains(key), "Key " + key + " not found in the context");
     }
@@ -264,7 +264,7 @@ public class ContextTest {
   void testReadPairs() throws IOException {
     setupComplexContext();
     var expected = Set.of("custom", "owl", "datacite", "xsd", "rdfs");
-    var given = context.getImmutablePairs();
+    var given = context.readPairs();
     var keys = given.keySet();
     var values = given.values();
     for (String key : expected) {

--- a/src/test/java/edu/kit/datamanager/ro_crate/context/ContextTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/context/ContextTest.java
@@ -1,6 +1,7 @@
 package edu.kit.datamanager.ro_crate.context;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -14,6 +15,7 @@ import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -140,9 +142,9 @@ public class ContextTest {
   void doubledContextUrlsTest() throws JsonProcessingException {
     String url = "www.example.com";
     RoCrateMetadataContext context = new RoCrateMetadataContext();
-    assertFalse(context.url.contains(url));
+    assertFalse(context.urls.contains(url));
     context.addToContextFromUrl(url);
-    assertTrue(context.url.contains(url));
+    assertTrue(context.urls.contains(url));
 
     RoCrateMetadataContext contextDoubled = new RoCrateMetadataContext();
     contextDoubled.addToContextFromUrl(url);
@@ -223,5 +225,31 @@ public class ContextTest {
             .addProperty("http://example.org/Thing", "Some thing")
             .build();
     assertTrue(this.context.checkEntity(validEntity));
+  }
+
+  @Test
+  void testSetDeleteGetPair() {
+    String key = "key";
+    String value = "value";
+    context.addToContext(key, value);
+    assertEquals(value, context.getValueOf(key));
+    context.deleteValuePairFromContext(key);
+    assertNull(context.getValueOf(key));
+  }
+
+  @Test
+  void testReadDeleteGetPair() throws IOException {
+    final String crateManifestPath = "/crates/extendedContextExample/ro-crate-metadata.json";
+    ContextTest.class.getResource(crateManifestPath).getPath();
+    ObjectMapper objectMapper = MyObjectMapper.getMapper();
+    JsonNode jsonNode = objectMapper.readTree(ContextTest.class.getResourceAsStream(crateManifestPath));
+    this.context = new RoCrateMetadataContext(jsonNode.get("@context"));
+    String key = "custom";
+    String value = "_:";
+    assertEquals(value, context.getValueOf(key));
+    context.deleteValuePairFromContext(key);
+    assertNull(context.getValueOf(key));
+    context.addToContext(key, value);
+    assertEquals(value, context.getValueOf(key));
   }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/context/ContextTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/context/ContextTest.java
@@ -1,6 +1,5 @@
 package edu.kit.datamanager.ro_crate.context;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -32,7 +31,6 @@ public class ContextTest {
     this.context = new RoCrateMetadataContext();
 
     final String crateManifestPath = "/crates/extendedContextExample/ro-crate-metadata.json";
-    ContextTest.class.getResource(crateManifestPath).getPath();
     ObjectMapper objectMapper = MyObjectMapper.getMapper();
     JsonNode jsonNode = objectMapper.readTree(ContextTest.class.getResourceAsStream(crateManifestPath));
     this.complexContext = new RoCrateMetadataContext(jsonNode.get("@context"));
@@ -147,7 +145,7 @@ public class ContextTest {
   }
 
   @Test
-  void doubledContextUrlsTest() throws JsonProcessingException {
+  void doubledContextUrlsTest() {
     String url = "www.example.com";
     RoCrateMetadataContext context = new RoCrateMetadataContext();
     assertFalse(context.urls.contains(url));
@@ -246,7 +244,7 @@ public class ContextTest {
   }
 
   @Test
-  void testReadDeleteGetPair() throws IOException {
+  void testReadDeleteGetPair() {
     String key = "custom";
     String value = "_:";
     assertEquals(value, this.complexContext.readValueOf(key));
@@ -257,7 +255,7 @@ public class ContextTest {
   }
 
   @Test
-  void testReadKeys() throws IOException {
+  void testReadKeys() {
     var expected = Set.of("custom", "owl", "datacite", "xsd", "rdfs");
     var given = this.complexContext.readKeys();
     for (String key : expected) {
@@ -266,7 +264,7 @@ public class ContextTest {
   }
 
   @Test
-  void testReadPairs() throws IOException {
+  void testReadPairs() {
     var expected = Set.of("custom", "owl", "datacite", "xsd", "rdfs");
     var given = this.complexContext.readPairs();
     var keys = given.keySet();

--- a/src/test/java/edu/kit/datamanager/ro_crate/context/ContextTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/context/ContextTest.java
@@ -261,6 +261,8 @@ public class ContextTest {
     for (String key : expected) {
       assertTrue(given.contains(key), "Key " + key + " not found in the context");
     }
+    // prove immutability
+    assertThrows(UnsupportedOperationException.class, () -> given.add("newKey"));
   }
 
   @Test
@@ -273,5 +275,7 @@ public class ContextTest {
       assertTrue(keys.contains(key), "Key " + key + " not found in the context");
       values.forEach(s -> assertFalse(s.isEmpty(), "Value for key " + key + " is empty"));
     }
+    // prove immutability
+    assertThrows(UnsupportedOperationException.class, () -> given.put("newKey", "newValue"));
   }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/TestRemoveAddContext.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/TestRemoveAddContext.java
@@ -9,8 +9,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import edu.kit.datamanager.ro_crate.HelpFunctions;
 import edu.kit.datamanager.ro_crate.RoCrate;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestRemoveAddContext {
   @Test
@@ -45,5 +46,32 @@ public class TestRemoveAddContext {
     assertEquals(value, crate.getMetadataContextValueOf(key));
     crate.deleteValuePairFromContext(key);
     assertNull(crate.getMetadataContextValueOf(key));
+  }
+
+  @Test
+  void testReadContextKeys() {
+    String crateManifestPath = "/crates/extendedContextExample/";
+    crateManifestPath = TestRemoveAddContext.class.getResource(crateManifestPath).getPath();
+    RoCrate crate = new RoCrateReader(new FolderReader()).readCrate(crateManifestPath);
+    var expected = Set.of("custom", "owl", "datacite", "xsd", "rdfs");
+    var given = crate.getMetadataContextKeys();
+    for (String key : expected) {
+        assertTrue(given.contains(key), "Key " + key + " not found in the context");
+    }
+  }
+
+  @Test
+  void testReadContextPairs() {
+    String crateManifestPath = "/crates/extendedContextExample/";
+    crateManifestPath = TestRemoveAddContext.class.getResource(crateManifestPath).getPath();
+    RoCrate crate = new RoCrateReader(new FolderReader()).readCrate(crateManifestPath);
+    var expected = Set.of("custom", "owl", "datacite", "xsd", "rdfs");
+    var given = crate.getMetadataContextPairs();
+    var keys = given.keySet();
+    var values = given.values();
+    for (String key : expected) {
+        assertTrue(keys.contains(key), "Key " + key + " not found in the context");
+        values.forEach(s -> assertFalse(s.isEmpty(), "Value for key " + key + " is empty"));
+    }
   }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/TestRemoveAddContext.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/TestRemoveAddContext.java
@@ -62,6 +62,8 @@ public class TestRemoveAddContext {
     for (String key : expected) {
         assertTrue(given.contains(key), "Key " + key + " not found in the context");
     }
+    // prove immutability
+    assertThrows(UnsupportedOperationException.class, () -> given.add("newKey"));
   }
 
   @Test
@@ -74,5 +76,7 @@ public class TestRemoveAddContext {
         assertTrue(keys.contains(key), "Key " + key + " not found in the context");
         values.forEach(s -> assertFalse(s.isEmpty(), "Value for key " + key + " is empty"));
     }
+    // prove immutability
+    assertThrows(UnsupportedOperationException.class, () -> given.put("newKey", "newValue"));
   }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/TestRemoveAddContext.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/TestRemoveAddContext.java
@@ -7,6 +7,7 @@ import edu.kit.datamanager.ro_crate.RoCrate;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -19,7 +20,7 @@ public class TestRemoveAddContext {
   @BeforeEach
   void setup() {
     String crateManifestPath = "/crates/extendedContextExample/";
-    crateManifestPath = TestRemoveAddContext.class.getResource(crateManifestPath).getPath();
+    crateManifestPath = Objects.requireNonNull(TestRemoveAddContext.class.getResource(crateManifestPath)).getPath();
     this.crateWithComplexContext = new RoCrateReader(new FolderReader()).readCrate(crateManifestPath);
   }
 

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/TestRemoveAddContext.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/TestRemoveAddContext.java
@@ -50,15 +50,15 @@ public class TestRemoveAddContext {
   void testReadDeleteGetContextPair() {
     String key = "custom";
     String value = "_:";
-    assertEquals(value, this.crateWithComplexContext.readMetadataContextValueOf(key));
+    assertEquals(value, this.crateWithComplexContext.getMetadataContextValueOf(key));
     this.crateWithComplexContext.deleteValuePairFromContext(key);
-    assertNull(this.crateWithComplexContext.readMetadataContextValueOf(key));
+    assertNull(this.crateWithComplexContext.getMetadataContextValueOf(key));
   }
 
   @Test
   void testReadContextKeys() {
     var expected = Set.of("custom", "owl", "datacite", "xsd", "rdfs");
-    var given = this.crateWithComplexContext.readMetadataContextKeys();
+    var given = this.crateWithComplexContext.getMetadataContextKeys();
     for (String key : expected) {
         assertTrue(given.contains(key), "Key " + key + " not found in the context");
     }
@@ -69,7 +69,7 @@ public class TestRemoveAddContext {
   @Test
   void testReadContextPairs() {
     var expected = Set.of("custom", "owl", "datacite", "xsd", "rdfs");
-    var given = this.crateWithComplexContext.readMetadataContextPairs();
+    var given = this.crateWithComplexContext.getMetadataContextPairs();
     var keys = given.keySet();
     var values = given.values();
     for (String key : expected) {

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/TestRemoveAddContext.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/TestRemoveAddContext.java
@@ -1,11 +1,16 @@
 package edu.kit.datamanager.ro_crate.crate;
 
+import edu.kit.datamanager.ro_crate.reader.FolderReader;
+import edu.kit.datamanager.ro_crate.reader.RoCrateReader;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import edu.kit.datamanager.ro_crate.HelpFunctions;
 import edu.kit.datamanager.ro_crate.RoCrate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TestRemoveAddContext {
   @Test
@@ -30,4 +35,15 @@ public class TestRemoveAddContext {
 
   }
 
+  @Test
+  void testReadDeleteGetContextPair() {
+    String crateManifestPath = "/crates/extendedContextExample/";
+    crateManifestPath = TestRemoveAddContext.class.getResource(crateManifestPath).getPath();
+    RoCrate crate = new RoCrateReader(new FolderReader()).readCrate(crateManifestPath);
+    String key = "custom";
+    String value = "_:";
+    assertEquals(value, crate.getMetadataContextValueOf(key));
+    crate.deleteValuePairFromContext(key);
+    assertNull(crate.getMetadataContextValueOf(key));
+  }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/TestRemoveAddContext.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/TestRemoveAddContext.java
@@ -43,9 +43,9 @@ public class TestRemoveAddContext {
     RoCrate crate = new RoCrateReader(new FolderReader()).readCrate(crateManifestPath);
     String key = "custom";
     String value = "_:";
-    assertEquals(value, crate.getMetadataContextValueOf(key));
+    assertEquals(value, crate.readMetadataContextValueOf(key));
     crate.deleteValuePairFromContext(key);
-    assertNull(crate.getMetadataContextValueOf(key));
+    assertNull(crate.readMetadataContextValueOf(key));
   }
 
   @Test
@@ -54,7 +54,7 @@ public class TestRemoveAddContext {
     crateManifestPath = TestRemoveAddContext.class.getResource(crateManifestPath).getPath();
     RoCrate crate = new RoCrateReader(new FolderReader()).readCrate(crateManifestPath);
     var expected = Set.of("custom", "owl", "datacite", "xsd", "rdfs");
-    var given = crate.getMetadataContextKeys();
+    var given = crate.readMetadataContextKeys();
     for (String key : expected) {
         assertTrue(given.contains(key), "Key " + key + " not found in the context");
     }
@@ -66,7 +66,7 @@ public class TestRemoveAddContext {
     crateManifestPath = TestRemoveAddContext.class.getResource(crateManifestPath).getPath();
     RoCrate crate = new RoCrateReader(new FolderReader()).readCrate(crateManifestPath);
     var expected = Set.of("custom", "owl", "datacite", "xsd", "rdfs");
-    var given = crate.getMetadataContextPairs();
+    var given = crate.readMetadataContextPairs();
     var keys = given.keySet();
     var values = given.values();
     for (String key : expected) {

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/TestRemoveAddContext.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/TestRemoveAddContext.java
@@ -2,18 +2,27 @@ package edu.kit.datamanager.ro_crate.crate;
 
 import edu.kit.datamanager.ro_crate.reader.FolderReader;
 import edu.kit.datamanager.ro_crate.reader.RoCrateReader;
-import org.junit.jupiter.api.Test;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-
 import edu.kit.datamanager.ro_crate.HelpFunctions;
 import edu.kit.datamanager.ro_crate.RoCrate;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+
 import java.util.Set;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestRemoveAddContext {
+  private RoCrate crateWithComplexContext;
+
+  @BeforeEach
+  void setup() {
+    String crateManifestPath = "/crates/extendedContextExample/";
+    crateManifestPath = TestRemoveAddContext.class.getResource(crateManifestPath).getPath();
+    this.crateWithComplexContext = new RoCrateReader(new FolderReader()).readCrate(crateManifestPath);
+  }
+
   @Test
   void testAddRemoveValuePair() throws JsonProcessingException {
     RoCrate crate = new RoCrate.RoCrateBuilder().addValuePairToContext("key", "value").build();
@@ -38,23 +47,17 @@ public class TestRemoveAddContext {
 
   @Test
   void testReadDeleteGetContextPair() {
-    String crateManifestPath = "/crates/extendedContextExample/";
-    crateManifestPath = TestRemoveAddContext.class.getResource(crateManifestPath).getPath();
-    RoCrate crate = new RoCrateReader(new FolderReader()).readCrate(crateManifestPath);
     String key = "custom";
     String value = "_:";
-    assertEquals(value, crate.readMetadataContextValueOf(key));
-    crate.deleteValuePairFromContext(key);
-    assertNull(crate.readMetadataContextValueOf(key));
+    assertEquals(value, this.crateWithComplexContext.readMetadataContextValueOf(key));
+    this.crateWithComplexContext.deleteValuePairFromContext(key);
+    assertNull(this.crateWithComplexContext.readMetadataContextValueOf(key));
   }
 
   @Test
   void testReadContextKeys() {
-    String crateManifestPath = "/crates/extendedContextExample/";
-    crateManifestPath = TestRemoveAddContext.class.getResource(crateManifestPath).getPath();
-    RoCrate crate = new RoCrateReader(new FolderReader()).readCrate(crateManifestPath);
     var expected = Set.of("custom", "owl", "datacite", "xsd", "rdfs");
-    var given = crate.readMetadataContextKeys();
+    var given = this.crateWithComplexContext.readMetadataContextKeys();
     for (String key : expected) {
         assertTrue(given.contains(key), "Key " + key + " not found in the context");
     }
@@ -62,11 +65,8 @@ public class TestRemoveAddContext {
 
   @Test
   void testReadContextPairs() {
-    String crateManifestPath = "/crates/extendedContextExample/";
-    crateManifestPath = TestRemoveAddContext.class.getResource(crateManifestPath).getPath();
-    RoCrate crate = new RoCrateReader(new FolderReader()).readCrate(crateManifestPath);
     var expected = Set.of("custom", "owl", "datacite", "xsd", "rdfs");
-    var given = crate.readMetadataContextPairs();
+    var given = this.crateWithComplexContext.readMetadataContextPairs();
     var keys = given.keySet();
     var values = given.values();
     for (String key : expected) {

--- a/src/test/resources/crates/extendedContextExample/ro-crate-metadata.json
+++ b/src/test/resources/crates/extendedContextExample/ro-crate-metadata.json
@@ -1,0 +1,28 @@
+{
+  "@context": [
+    "https://w3id.org/ro/crate/1.1/context",
+    {
+      "owl": "https://www.w3.org/TR/owl-ref/#",
+      "datacite": "http://datacite.org/schema/kernel-4#",
+      "xsd": "http://www.w3.org/2001/XMLSchema#",
+      "rdfs": "https://www.w3.org/2000/01/rdf-schema#",
+      "custom": "_:"
+    }
+  ],
+  "@graph": [
+    {
+      "@id": "./",
+      "@type": "Dataset",
+      "name" : "minimal",
+      "description" : "minimal RO_crate",
+      "datePublished": "2024",
+      "license": {"@id": "https://creativecommons.org/licenses/by-nc-sa/3.0/au/"}
+    },
+    {
+      "@type": "CreativeWork",
+      "@id": "ro-crate-metadata.json",
+      "conformsTo": {"@id": "https://w3id.org/ro/crate/1.1"},
+      "about": {"@id": "./"}
+    }
+  ]
+}


### PR DESCRIPTION
This adds a few methods to read from the crate context.

- get value to a given key (there is no way to modify or assign it)
- get immutable set of keys
- get immutable map of key-value-pairs

The immutability of the return values is given in the Javadocs.