### PR TITLE
Experiment for improved context control

### DIFF
--- a/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
@@ -233,12 +233,45 @@ public class RoCrate implements Crate {
         this.untrackedFiles = files;
     }
 
+    private boolean isKeyUnused(String key, ObjectNode node) {
+        Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+        while (fields.hasNext()) {
+            Map.Entry<String, JsonNode> entry = fields.next();
+            String fieldName = entry.getKey();
+            if (fieldName.startsWith(key)) {
+                return false;
+            }
+            JsonNode value = entry.getValue();
+            if (value.isObject()) {
+                if (!isKeyUnused(key, (ObjectNode) value)) {
+                    return false;
+                }
+            } else if (value.isArray()) {
+                for (JsonNode element : value) {
+                    if (element.isObject() && !isKeyUnused(key, (ObjectNode) element)) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    public boolean cleanupContext() {
+        // TODO we are missing the relations between the pairs and the URL, in order to check if a URL can be removed.
+        var contextUrls = this.metadataContext.getUrls();
+        var contextAllKeys = this.metadataContext.getKeys();
+        var contextExplicitKeys = this.metadataContext.getExplicitKeys();
+    }
+
     @Override
+    @Deprecated(forRemoval = true)
     public void deleteValuePairFromContext(String key) {
         this.metadataContext.deleteValuePairFromContext(key);
     }
 
     @Override
+    @Deprecated(forRemoval = true)
     public void deleteUrlFromContext(String key) {
         this.metadataContext.deleteUrlFromContext(key);
     }

--- a/src/main/java/edu/kit/datamanager/ro_crate/context/CrateMetadataContext.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/context/CrateMetadataContext.java
@@ -39,10 +39,23 @@ public interface CrateMetadataContext {
   Set<String> getKeys();
 
   /**
+   * Get an immutable collection of the keys in the metadata context that are
+   * explicitly set, not indirectly using a URL.
+   * @return the explicitly set keys in the metadata context
+   */
+  Set<String> getExplicitKeys();
+
+  /**
   * Get an immutable map of the context.
   * @return an immutable map containing the context key-value pairs
   */
   Map<String, String> getPairs();
+
+  /**
+   * Get an immutable collection of the urls in the metadata context.
+   * @return the urls in the metadata context
+   */
+  Set<String> getUrls();
 
   void deleteValuePairFromContext(String key);
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
@@ -215,11 +215,21 @@ public class RoCrateMetadataContext implements CrateMetadataContext {
   }
 
   @Override
+  public Set<String> getExplicitKeys() {
+    return Set.copyOf(this.other.keySet());
+  }
+
+  @Override
   public Map<String, String> getPairs() {
     Map<String, String> merged = new HashMap<>();
     merged.putAll(this.contextMap);
     merged.putAll(this.other);
     return Map.copyOf(merged);
+  }
+
+  @Override
+  public Set<String> getUrls() {
+    return Set.copyOf(this.urls);
   }
 
 


### PR DESCRIPTION
Experimental, early WIP. This may contain breaking changes (we'll see) and then likely land in a v3.0.0, maybe.

Experiment to implement auto-control for the context without bringing it to invalid states.

Rough idea:

- Adding things to context is allowed (Explicitly? Implicitly?)
- Removing things is only possible under certain circumstances. One may ask for a cleanup of the context. There may exist cleanup requests for everything, or sub-elements like urls or key-value-pairs.
- Fixing typos or http->https replacements (inline value change) can be done by explicit methods to do so.
- All changes are only applied if validation after the change is successful (rollback otherwise). For example, values should be URIs/IRIs, and so on.
- Implicit cleanup could happen when exporting a crate.

Drawbacks:

- Likely will have performance impacts
- In the end, the implementation is likely breaking and requires deprecating methods in beforehand
- Editors that use ro-crate-java will also have less direct control over context (and need to adapt the pattern or we offer two implementations)