### PR TITLE
Investigation in renaming directories in zip writers

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,6 @@ on:
   push:
     branches: [ main, development ]
   pull_request:
-    branches: [ main, development ]
   workflow_dispatch:
 
 env:

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataEntity.java
@@ -65,6 +65,7 @@ public class DataEntity extends AbstractEntity {
      * @throws ZipException when something goes wrong with the writing to the
      * zip file.
      */
+    @Deprecated(since = "2.1.0", forRemoval = true)
     public void saveToZip(ZipFile zipFile) throws ZipException {
         if (this.path != null) {
             ZipParameters zipParameters = new ZipParameters();
@@ -82,6 +83,7 @@ public class DataEntity extends AbstractEntity {
      * zip file.
      * @throws IOException If opening the file input stream fails.
      */
+    @Deprecated(since = "2.1.0", forRemoval = true)
     public void saveToStream(ZipOutputStream zipStream) throws ZipException, IOException {
         if (this.path != null) {
             ZipUtil.addFileToZipStream(zipStream, this.path.toFile(), this.getId());
@@ -95,6 +97,7 @@ public class DataEntity extends AbstractEntity {
      * @param file the folder location where the entity should be written.
      * @throws IOException if something goes wrong with the writing.
      */
+    @Deprecated(since = "2.1.0", forRemoval = true)
     public void savetoFile(File file) throws IOException {
         if (this.getPath() != null) {
             if (this.getPath().toFile().isDirectory()) {

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/FolderStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/FolderStrategy.java
@@ -25,6 +25,16 @@ public class FolderStrategy implements GenericWriterStrategy<String> {
 
     private static final Logger logger = LoggerFactory.getLogger(FolderStrategy.class);
 
+    protected void saveDataEntity(DataEntity dataEntity, File file) throws IOException {
+        if (dataEntity.getPath() != null) {
+            if (dataEntity.getPath().toFile().isDirectory()) {
+                FileUtils.copyDirectory(dataEntity.getPath().toFile(), file.toPath().resolve(dataEntity.getId()).toFile());
+            } else {
+                FileUtils.copyFile(dataEntity.getPath().toFile(), file.toPath().resolve(dataEntity.getId()).toFile());
+            }
+        }
+    }
+
     @Override
     public void save(Crate crate, String destination) {
         File file = new File(destination);
@@ -54,7 +64,7 @@ public class FolderStrategy implements GenericWriterStrategy<String> {
         }
         for (DataEntity dataEntity : crate.getAllDataEntities()) {
             try {
-                dataEntity.savetoFile(file);
+                this.saveDataEntity(dataEntity, file);
             } catch (IOException e) {
                 logger.error("Cannot save " + dataEntity.getId() + " to destination folder!", e);
             }

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/ZipStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/ZipStrategy.java
@@ -35,17 +35,25 @@ public class ZipStrategy implements GenericWriterStrategy<String> {
         }
     }
 
-    private void saveDataEntities(Crate crate, ZipFile zipFile) {
+    protected void saveDataEntities(Crate crate, ZipFile zipFile) {
         for (DataEntity dataEntity : crate.getAllDataEntities()) {
             try {
-                dataEntity.saveToZip(zipFile);
+                this.saveDataEntity(dataEntity, zipFile);
             } catch (ZipException e) {
                 logger.error("Could not save " + dataEntity.getId() + " to zip file!", e);
             }
         }
     }
 
-    private void saveMetadataJson(Crate crate, ZipFile zipFile) {
+    protected void saveDataEntity(DataEntity dataEntity, ZipFile zipFile) throws ZipException {
+        if (dataEntity.getPath() != null) {
+            ZipParameters zipParameters = new ZipParameters();
+            zipParameters.setFileNameInZip(dataEntity.getId());
+            zipFile.addFile(dataEntity.getPath().toFile(), zipParameters);
+        }
+    }
+
+    protected void saveMetadataJson(Crate crate, ZipFile zipFile) {
         try {
             // write the metadata.json file
             ZipParameters zipParameters = new ZipParameters();

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/ZipStreamStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/ZipStreamStrategy.java
@@ -12,6 +12,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import edu.kit.datamanager.ro_crate.util.ZipUtil;
+import net.lingala.zip4j.exception.ZipException;
 import net.lingala.zip4j.io.outputstream.ZipOutputStream;
 import net.lingala.zip4j.model.ZipParameters;
 import org.slf4j.Logger;
@@ -36,17 +40,24 @@ public class ZipStreamStrategy implements GenericWriterStrategy<OutputStream> {
         }
     }
 
-    private void saveDataEntities(Crate crate, ZipOutputStream zipStream) {
+    protected void saveDataEntities(Crate crate, ZipOutputStream zipStream) {
         for (DataEntity dataEntity : crate.getAllDataEntities()) {
             try {
-                dataEntity.saveToStream(zipStream);
+                this.saveDataEntity(dataEntity, zipStream);
             } catch (IOException e) {
                 logger.error("Could not save {} to zip stream!", dataEntity.getId(), e);
             }
         }
     }
 
-    private void saveMetadataJson(Crate crate, ZipOutputStream zipStream) {
+    protected void saveDataEntity(DataEntity dataEntity, ZipOutputStream zipStream) throws ZipException, IOException {
+        Path path = dataEntity.getPath();
+        if (path != null) {
+            ZipUtil.addFileToZipStream(zipStream, path.toFile(), dataEntity.getId());
+        }
+    }
+
+    protected void saveMetadataJson(Crate crate, ZipOutputStream zipStream) {
         try {
             // write the metadata.json file
             ZipParameters zipParameters = new ZipParameters();

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/CrateWriterTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/CrateWriterTest.java
@@ -123,9 +123,9 @@ abstract class CrateWriterTest {
         Path extractionPath = tempDir.resolve("extracted_for_testing");
         this.ensureCrateIsExtractedIn(pathToZip, extractionPath);
         // compare the extracted directory with the correct one
-        assertTrue(HelpFunctions.compareTwoDir(
+        HelpFunctions.assertEqualDirectories(
                 correctCrate.toFile(),
-                extractionPath.toFile()));
+                extractionPath.toFile());
         HelpFunctions.compareCrateJsonToFileInResources(
                 builtCrate,
                 "/json/crate/fileAndDir.json");


### PR DESCRIPTION
I think I've found a severe bug, which I tried starting to investigate/fix here. I will open an issue if I can definitely confirm it is not just me. I found it while unifying the tests for the writers in #247.

The issue would be that using zip (and the new zipStream) writers, folders seem not to be copied recursively and are not properly renamed according to their ID property.

I started by collecting the different saving mechanisms in the according strategies. This already changes the result, because we now do not use the overridden save function in DataSetEntity#saveTo*. I think I should stash this as of now and figure the actual issue.

Will fix tomorrow.

- [ ] go through tests and make sure they make sense and test one single aspect. For example, the failing test: why should it fail? This is rather a test of the test currently. Also it assumes that files get renamed (which works) but it belongs to the first test, which also discovered it does not work for directories.
- [ ] improve assertions to point out the error more clearly so I do not have to debug temporary directories.
- [ ] fix tests changing the current structure, if possible, to make sure we understand where the error was. 
- [ ] restructure writing responsibilities, deprecating old responsibilities.