### PR TITLE
Fix renaming of data set entities

### DIFF
--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataEntity.java
@@ -8,9 +8,7 @@ import static edu.kit.datamanager.ro_crate.special.IdentifierUtils.isUrl;
 import edu.kit.datamanager.ro_crate.util.ZipUtil;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -48,11 +46,12 @@ public class DataEntity extends AbstractEntity {
 
     /**
      * Adds an author ID to the entity.
-     *
+     * <p>
      * Calling this multiple times will add multiple author IDs.
      *
      * @param id the identifier of the author.
      */
+    @SuppressWarnings("unused")
     public void addAuthorId(String id) {
         this.addIdProperty("author", id);
     }
@@ -125,7 +124,7 @@ public class DataEntity extends AbstractEntity {
          * <p>
          * If the ID has not been set manually in beforehand, it will be derived
          * from the path. Use {@link #setId(String)} to override it or set it in
-         * beforehand. Note that another call of {@link #setLocation(Path)} will
+         * beforehand. Note that another call of this method will
          * not override the ID as it has been set by the previous call!
          *
          * @param path the location of the data. May be null, in which case
@@ -159,7 +158,7 @@ public class DataEntity extends AbstractEntity {
         /**
          * Same as {@link #setLocation(Path)} but instead of associating this
          * entity with a file, it will point to some place on the internet.
-         *
+         * <p>
          * Via the specification, this means the uri will be set as the ID. This
          * call is therefore equivalent to {@link #setId(String)}.
          *
@@ -214,7 +213,7 @@ public class DataEntity extends AbstractEntity {
 
     /**
      * Data Entity builder class that allows for easier data entity creation.
-     *
+     * <p>
      * If not explicitly mentioned, all methods avoid Exceptions and will
      * silently ignore null-parameters, in which case nothing will happen. Use
      * the available *WithExceptions-methods in case you need them.

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataEntity.java
@@ -117,8 +117,12 @@ public class DataEntity extends AbstractEntity {
         private List<String> authors = new ArrayList<>();
 
         /**
-         * Sets the location of the data entity.
-         *
+         * Sets the location of the data entity to make a copy from when writing the crate.
+         * <p>
+         * Use this if you want to copy the associated file to the crate.
+         * Do not use it if the file should already be considered (e.g.
+         * as part of a DataSetEntity).
+         * <p>
          * If the ID has not been set manually in beforehand, it will be derived
          * from the path. Use {@link #setId(String)} to override it or set it in
          * beforehand. Note that another call of {@link #setLocation(Path)} will

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataSetEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataSetEntity.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.exception.ZipException;
 import net.lingala.zip4j.io.outputstream.ZipOutputStream;
+import net.lingala.zip4j.model.ZipParameters;
 
 /**
  * A helping class for the creating of Data entities of type Dataset.
@@ -45,14 +46,20 @@ public class DataSetEntity extends DataEntity {
     @Override
     public void saveToZip(ZipFile zipFile) throws ZipException {
         if (this.getPath() != null) {
-            zipFile.addFolder(this.getPath().toFile());
+            ZipParameters parameters = new ZipParameters();
+            parameters.setRootFolderNameInZip(this.getId());
+            parameters.setIncludeRootFolder(false);
+            zipFile.addFolder(this.getPath().toFile(), parameters);
         }
     }
 
     @Override
-    public void saveToStream(ZipOutputStream zipOutputStream) throws ZipException, IOException {
+    public void saveToStream(ZipOutputStream zipOutputStream) throws IOException {
         if (this.getPath() != null) {
-            ZipUtil.addFolderToZipStream(zipOutputStream, this.getPath().toAbsolutePath().toString(), this.getPath().getFileName().toString());
+            ZipUtil.addFolderToZipStream(
+                    zipOutputStream,
+                    this.getPath().toAbsolutePath().toString(),
+                    this.getId());
         }
     }
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/util/ZipUtil.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/util/ZipUtil.java
@@ -13,9 +13,24 @@ import net.lingala.zip4j.model.ZipParameters;
  */
 public class ZipUtil {
 
-    public static void addFolderToZipStream(ZipOutputStream zipOutputStream, File folder, String parentPath) throws IOException {
+    /**
+     * Adds a folder and its contents to a ZipOutputStream.
+     *
+     * @param zipOutputStream The ZipOutputStream to which the folder will be added.
+     * @param folder The folder to be added.
+     * @param parentPath The path in the zip file where the folder will be added.
+     * @throws IOException If an I/O error occurs.
+     */
+    public static void addFolderToZipStream(
+            ZipOutputStream zipOutputStream,
+            File folder,
+            String parentPath
+    ) throws IOException {
         if (!folder.exists() || !folder.isDirectory()) {
-            throw new IllegalArgumentException("The provided folder path is not a valid directory: " + folder.getAbsolutePath());
+            throw new IllegalArgumentException(
+                    "The provided folder path is not a valid directory: %s"
+                            .formatted(folder.getAbsolutePath())
+            );
         }
 
         File[] files = folder.listFiles();
@@ -33,11 +48,34 @@ public class ZipUtil {
         }
     }
 
-    public static void addFolderToZipStream(ZipOutputStream zipOutputStream, String folderPath, String parentPath) throws IOException {
+    /**
+     * Adds a folder and its contents to a ZipOutputStream.
+     * @param zipOutputStream The ZipOutputStream to which the folder will be added.
+     * @param folderPath The path of the folder to be added.
+     * @param parentPath The path in the zip file where the folder will be added.
+     * @throws IOException If an I/O error occurs.
+     */
+    public static void addFolderToZipStream(
+            ZipOutputStream zipOutputStream,
+            String folderPath,
+            String parentPath
+    ) throws IOException {
         addFolderToZipStream(zipOutputStream, new File(folderPath), parentPath);
     }
 
-    public static void addFileToZipStream(ZipOutputStream zipOutputStream, File file, String zipEntryPath) throws IOException {
+    /**
+     * Adds a file to a ZipOutputStream.
+     *
+     * @param zipOutputStream The ZipOutputStream to which the file will be added.
+     * @param file The file to be added.
+     * @param zipEntryPath The path in the zip file where the file will be added.
+     * @throws IOException If an I/O error occurs.
+     */
+    public static void addFileToZipStream(
+            ZipOutputStream zipOutputStream,
+            File file,
+            String zipEntryPath
+    ) throws IOException {
         ZipParameters zipParameters = new ZipParameters();
         zipParameters.setFileNameInZip(zipEntryPath);
         zipOutputStream.putNextEntry(zipParameters);

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/CrateWriterTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/CrateWriterTest.java
@@ -80,6 +80,10 @@ abstract class CrateWriterTest {
                 Files.isDirectory(extractionPath.resolve("lots_of_little_files/")),
                 "The directory 'lots_of_little_files' should be present"
         );
+        assertTrue(
+                Files.isDirectory(extractionPath.resolve("lots_of_little_files/").resolve("subdir")),
+                "The directory 'lots_of_little_files/subdir' should be present"
+        );
     }
 
     /**

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/CrateWriterTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/CrateWriterTest.java
@@ -50,7 +50,15 @@ abstract class CrateWriterTest {
         Path writtenCrate = tempDir.resolve("written-crate");
         Path extractionPath = tempDir.resolve("checkMe");
         {
-            RoCrate builtCrate = getCrateWithFileAndDir(pathToFile, pathToDir).build();
+            RoCrate builtCrate = getCrateWithFileAndDir(pathToFile, pathToDir)
+                    .addDataEntity(new DataSetEntity.DataSetBuilder()
+                            .addProperty("name", "Subdir")
+                            .addProperty("description", "Some subdir")
+                            .setLocationWithExceptions(pathToDir.resolve("subdir"))
+                            .setId("lots_of_little_files/subdir-renamed/")
+                            .build()
+                    )
+                    .build();
             this.saveCrate(builtCrate, writtenCrate);
             this.ensureCrateIsExtractedIn(writtenCrate, extractionPath);
         }
@@ -82,6 +90,16 @@ abstract class CrateWriterTest {
         );
         assertTrue(
                 Files.isDirectory(extractionPath.resolve("lots_of_little_files/").resolve("subdir")),
+                "The directory 'lots_of_little_files/subdir' should be present"
+        );
+
+        /*
+         * As we added another DataSetEntity with location, the subdir should have a renamed copy as well
+         * Note: If this behavior is to be changed later on, we possibly need to change the documentation
+         *  of {@link AbstractDataEntityBuilder#setLocation(Path)}.
+         */
+        assertTrue(
+                Files.isDirectory(extractionPath.resolve("lots_of_little_files/").resolve("subdir-renamed")),
                 "The directory 'lots_of_little_files/subdir' should be present"
         );
     }


### PR DESCRIPTION
> **This branch is based on #247 and should be merged after it!**

This fixes a bug where dataset entities would not adjust their names given the CrateWriter\<ZipStrategy\> (and the not yet released CrateWriter\<ZipStreamStrategy\>).