### PR TITLE
Support .ELN-style crates in all zip readers and writers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,6 @@ dependencies {
     implementation group: 'commons-io', name: 'commons-io', version: '2.19.0'
     // read from and write to zip files
     implementation group: 'net.lingala.zip4j', name: 'zip4j', version: '2.11.5'
-    implementation 'org.apache.commons:commons-compress:1.27.1'
     // compare json documents in tests
     implementation 'com.github.fslev:json-compare:7.0'
     // url validator

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     implementation group: 'commons-io', name: 'commons-io', version: '2.19.0'
     // read from and write to zip files
     implementation group: 'net.lingala.zip4j', name: 'zip4j', version: '2.11.5'
+    implementation 'org.apache.commons:commons-compress:1.27.1'
     // compare json documents in tests
     implementation 'com.github.fslev:json-compare:7.0'
     // url validator

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,11 @@ dependencies {
     implementation("org.freemarker:freemarker:2.3.34")
 }
 
+// enable -Xlint:deprecation
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs << "-Xlint:deprecation"
+}
+
 logging.captureStandardOutput LogLevel.INFO
 
 def signingTasks = tasks.withType(Sign)

--- a/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
@@ -113,9 +113,10 @@ public class RoCrateMetadataContext implements CrateMetadataContext {
     node.remove("@id");
     node.remove("@type");
 
-    Set<String> types = objectMapper.convertValue(entity.getProperties().get("@type"),
-        new TypeReference<>() {
-        });
+    Set<String> types = objectMapper.convertValue(
+            entity.getProperties().path("@type"),
+            new TypeReference<>() {}
+    );
     // check if the items in the array of types are present in the context
     for (String s : types) {
       // special cases:
@@ -181,7 +182,7 @@ public class RoCrateMetadataContext implements CrateMetadataContext {
         jsonNode = objectMapper.readValue(response.getEntity().getContent(),
             JsonNode.class);
       } catch (IOException e) {
-        System.err.println(String.format("Cannot get context from url %s", url));
+        System.err.printf("Cannot get context from url %s%n", url);
         return;
       }
       if (url.equals(DEFAULT_CONTEXT)) {

--- a/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/context/RoCrateMetadataContext.java
@@ -174,10 +174,9 @@ public class RoCrateMetadataContext implements CrateMetadataContext {
       }
     }
     if (jsonNode == null) {
-      CloseableHttpClient httpclient = HttpClients.createDefault();
       HttpGet httpGet = new HttpGet(url);
       CloseableHttpResponse response;
-      try {
+      try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
         response = httpclient.execute(httpGet);
         jsonNode = objectMapper.readValue(response.getEntity().getContent(),
             JsonNode.class);

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
@@ -558,17 +558,57 @@ public class AbstractEntity {
         }
 
         /**
-         * This sets everything from a json object to the property. Can be
-         * useful when the entity is already available somewhere.
+         * Deprecated. Equivalent to {@link #setAllIfValid(ObjectNode)}.
          *
          * @param properties the Json representing all the properties.
-         * @return the generic builder.
+         * @return the generic builder, either including all given properties
+         *          * or unchanged.
+         *
+         * @deprecated To enforce the user know what this method does,
+         *   we want the user to use one of the more explicitly named
+         *   methods {@link #setAllIfValid(ObjectNode)} or
+         *   {@link #setAllUnsafe(ObjectNode)}.
+         * @see #setAllIfValid(ObjectNode)
          */
+        @Deprecated(since = "2.1.0", forRemoval = true)
         public T setAll(ObjectNode properties) {
             if (AbstractEntity.entityValidation.entityValidation(properties)) {
                 this.properties = properties;
                 this.relatedItems.addAll(JsonUtilFunctions.getIdPropertiesFromJsonNode(properties));
             }
+            return self();
+        }
+
+        /**
+         * This sets everything from a json object to the property,
+         * <b>if the result is valid</b>. Otherwise, it will do <b>nothing</b>.
+         *
+         * @param properties the Json representing all the properties.
+         * @return the generic builder, either including all given properties
+         * or unchanged.
+         */
+        public T setAllIfValid(ObjectNode properties) {
+            if (AbstractEntity.entityValidation.entityValidation(properties)) {
+                this.properties = properties;
+                this.relatedItems.addAll(JsonUtilFunctions.getIdPropertiesFromJsonNode(properties));
+            }
+            return self();
+        }
+
+        /**
+         * This sets everything from a json object to the property. Can be
+         * useful when the entity is already available somewhere.
+         * <p>
+         * Errors on validation are printed, but everything will be added.
+         *
+         * @param properties the Json representing all the properties.
+         * @return the generic builder with all properties added.
+         */
+        public T setAllUnsafe(ObjectNode properties) {
+            // This will currently only print errors.
+            AbstractEntity.entityValidation.entityValidation(properties);
+            this.properties = properties;
+            this.relatedItems.addAll(JsonUtilFunctions.getIdPropertiesFromJsonNode(properties));
             return self();
         }
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
@@ -572,11 +572,7 @@ public class AbstractEntity {
          */
         @Deprecated(since = "2.1.0", forRemoval = true)
         public T setAll(ObjectNode properties) {
-            if (AbstractEntity.entityValidation.entityValidation(properties)) {
-                this.properties = properties;
-                this.relatedItems.addAll(JsonUtilFunctions.getIdPropertiesFromJsonNode(properties));
-            }
-            return self();
+            return setAllIfValid(properties);
         }
 
         /**

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
@@ -567,7 +567,7 @@ public class AbstractEntity {
          * @deprecated To enforce the user know what this method does,
          *   we want the user to use one of the more explicitly named
          *   methods {@link #setAllIfValid(ObjectNode)} or
-         *   {@link #setAllUnsafe(ObjectNode)}.
+         *   {@link #setAllIfValid(ObjectNode)}.
          * @see #setAllIfValid(ObjectNode)
          */
         @Deprecated(since = "2.1.0", forRemoval = true)
@@ -582,6 +582,11 @@ public class AbstractEntity {
         /**
          * This sets everything from a json object to the property,
          * <b>if the result is valid</b>. Otherwise, it will do <b>nothing</b>.
+         * <p>
+         * Valid means here that the json object needs to be flat as specified
+         * in the RO-Crate specification. In principle, this means that
+         * primitives and objects referencing an ID are allowed,
+         * as well as arrays of these.
          *
          * @param properties the Json representing all the properties.
          * @return the generic builder, either including all given properties
@@ -600,6 +605,7 @@ public class AbstractEntity {
          * useful when the entity is already available somewhere.
          * <p>
          * Errors on validation are printed, but everything will be added.
+         * For more about validation, see {@link #setAllIfValid(ObjectNode)}.
          *
          * @param properties the Json representing all the properties.
          * @return the generic builder with all properties added.

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/JsonDescriptor.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/JsonDescriptor.java
@@ -13,8 +13,8 @@ import edu.kit.datamanager.ro_crate.special.CrateVersion;
 
 public class JsonDescriptor extends ContextualEntity {
 
-    private static final String CONFORMS_TO = "conformsTo";
-    protected static final String ID = "ro-crate-metadata.json";
+    protected static final String CONFORMS_TO = "conformsTo";
+    public static final String ID = "ro-crate-metadata.json";
 
     /**
      * Returns a JsonDescriptor with the conformsTo value set to the latest stable

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/JsonDescriptor.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/contextual/JsonDescriptor.java
@@ -39,7 +39,7 @@ public class JsonDescriptor extends ContextualEntity {
 
     /**
      * Builder for the JsonDescriptor.
-     * 
+     * <p>
      * Defaults to the latest stable crate version and no other conformsTo values.
      */
     public static final class Builder {

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataEntity.java
@@ -12,9 +12,6 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import net.lingala.zip4j.ZipFile;
-import net.lingala.zip4j.exception.ZipException;
-import net.lingala.zip4j.model.ZipParameters;
 import org.apache.commons.io.FileUtils;
 
 /**
@@ -52,22 +49,6 @@ public class DataEntity extends AbstractEntity {
     @SuppressWarnings("unused")
     public void addAuthorId(String id) {
         this.addIdProperty("author", id);
-    }
-
-    /**
-     * If the data entity contains a physical file. This method will write it
-     * when the crate is being written to a zip archive.
-     *
-     * @param zipFile the zipFile where it should be written.
-     * @throws ZipException when something goes wrong with the writing to the
-     * zip file.
-     */
-    public void saveToZip(ZipFile zipFile) throws ZipException {
-        if (this.path != null) {
-            ZipParameters zipParameters = new ZipParameters();
-            zipParameters.setFileNameInZip(this.getId());
-            zipFile.addFile(this.path.toFile(), zipParameters);
-        }
     }
 
     /**

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataEntity.java
@@ -6,13 +6,10 @@ import edu.kit.datamanager.ro_crate.entities.AbstractEntity;
 import edu.kit.datamanager.ro_crate.entities.contextual.ContextualEntity;
 import static edu.kit.datamanager.ro_crate.special.IdentifierUtils.isUrl;
 
-import java.io.File;
-import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.io.FileUtils;
 
 /**
  * The base class of every data entity.
@@ -49,23 +46,6 @@ public class DataEntity extends AbstractEntity {
     @SuppressWarnings("unused")
     public void addAuthorId(String id) {
         this.addIdProperty("author", id);
-    }
-
-    /**
-     * If the data entity contains a physical file. This method will write it
-     * when the crate is being written to a folder.
-     *
-     * @param file the folder location where the entity should be written.
-     * @throws IOException if something goes wrong with the writing.
-     */
-    public void savetoFile(File file) throws IOException {
-        if (this.getPath() != null) {
-            if (this.getPath().toFile().isDirectory()) {
-                FileUtils.copyDirectory(this.getPath().toFile(), file.toPath().resolve(this.getId()).toFile());
-            } else {
-                FileUtils.copyFile(this.getPath().toFile(), file.toPath().resolve(this.getId()).toFile());
-            }
-        }
     }
 
     @JsonIgnore

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataEntity.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import edu.kit.datamanager.ro_crate.entities.AbstractEntity;
 import edu.kit.datamanager.ro_crate.entities.contextual.ContextualEntity;
 import static edu.kit.datamanager.ro_crate.special.IdentifierUtils.isUrl;
-import edu.kit.datamanager.ro_crate.util.ZipUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -15,7 +14,6 @@ import java.util.ArrayList;
 import java.util.List;
 import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.exception.ZipException;
-import net.lingala.zip4j.io.outputstream.ZipOutputStream;
 import net.lingala.zip4j.model.ZipParameters;
 import org.apache.commons.io.FileUtils;
 
@@ -69,21 +67,6 @@ public class DataEntity extends AbstractEntity {
             ZipParameters zipParameters = new ZipParameters();
             zipParameters.setFileNameInZip(this.getId());
             zipFile.addFile(this.path.toFile(), zipParameters);
-        }
-    }
-
-    /**
-     * If the data entity contains a physical file. This method will write it
-     * when the crate is being written to a zip archive.
-     *
-     * @param zipStream The zip output stream where it should be written.
-     * @throws ZipException when something goes wrong with the writing to the
-     * zip file.
-     * @throws IOException If opening the file input stream fails.
-     */
-    public void saveToStream(ZipOutputStream zipStream) throws ZipException, IOException {
-        if (this.path != null) {
-            ZipUtil.addFileToZipStream(zipStream, this.path.toFile(), this.getId());
         }
     }
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataSetEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataSetEntity.java
@@ -7,9 +7,6 @@ import edu.kit.datamanager.ro_crate.entities.serializers.HasPartSerializer;
 
 import java.util.HashSet;
 import java.util.Set;
-import net.lingala.zip4j.ZipFile;
-import net.lingala.zip4j.exception.ZipException;
-import net.lingala.zip4j.model.ZipParameters;
 
 /**
  * A helping class for the creating of Data entities of type Dataset.
@@ -38,16 +35,6 @@ public class DataSetEntity extends DataEntity {
 
     public void removeFromHasPart(String str) {
         this.hasPart.remove(str);
-    }
-
-    @Override
-    public void saveToZip(ZipFile zipFile) throws ZipException {
-        if (this.getPath() != null) {
-            ZipParameters parameters = new ZipParameters();
-            parameters.setRootFolderNameInZip(this.getId());
-            parameters.setIncludeRootFolder(false);
-            zipFile.addFolder(this.getPath().toFile(), parameters);
-        }
     }
 
     public void addToHasPart(String id) {

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataSetEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/data/DataSetEntity.java
@@ -4,14 +4,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import edu.kit.datamanager.ro_crate.entities.serializers.HasPartSerializer;
-import edu.kit.datamanager.ro_crate.util.ZipUtil;
-import java.io.IOException;
 
 import java.util.HashSet;
 import java.util.Set;
 import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.exception.ZipException;
-import net.lingala.zip4j.io.outputstream.ZipOutputStream;
 import net.lingala.zip4j.model.ZipParameters;
 
 /**
@@ -50,16 +47,6 @@ public class DataSetEntity extends DataEntity {
             parameters.setRootFolderNameInZip(this.getId());
             parameters.setIncludeRootFolder(false);
             zipFile.addFolder(this.getPath().toFile(), parameters);
-        }
-    }
-
-    @Override
-    public void saveToStream(ZipOutputStream zipOutputStream) throws IOException {
-        if (this.getPath() != null) {
-            ZipUtil.addFolderToZipStream(
-                    zipOutputStream,
-                    this.getPath().toAbsolutePath().toString(),
-                    this.getId());
         }
     }
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/validation/JsonSchemaValidation.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/validation/JsonSchemaValidation.java
@@ -60,6 +60,7 @@ public class JsonSchemaValidation implements EntityValidationStrategy {
     Set<ValidationMessage> errors = this.entitySchema.validate(entity);
     if (errors.size() != 0) {
       System.err.println("This entity does not comply to the basic RO-Crate entity structure.");
+      errors.forEach(error -> System.err.println(error.getMessage()));
       return false;
     }
     return true;

--- a/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/dataentities/ImportFromZenodo.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/dataentities/ImportFromZenodo.java
@@ -112,12 +112,12 @@ public class ImportFromZenodo {
       for (var entity : graph) {
         if (entity.get("@id").asText().equals(mainId)) {
           var dataEntity = new DataEntity.DataEntityBuilder()
-              .setAll((ObjectNode) entity).build();
+              .setAllUnsafe((ObjectNode) entity).build();
           crate.addDataEntity(dataEntity);
         } else {
           // here we have to think of a way to differentiate between data and contextual entities.
           var contextualEntity = new ContextualEntity.ContextualEntityBuilder()
-              .setAll((ObjectNode) entity).build();
+              .setAllUnsafe((ObjectNode) entity).build();
           crate.addContextualEntity(contextualEntity);
         }
       }

--- a/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/dataentities/ImportFromZenodo.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/dataentities/ImportFromZenodo.java
@@ -112,12 +112,12 @@ public class ImportFromZenodo {
       for (var entity : graph) {
         if (entity.get("@id").asText().equals(mainId)) {
           var dataEntity = new DataEntity.DataEntityBuilder()
-              .setAllIfValid((ObjectNode) entity).build();
+              .setAllUnsafe((ObjectNode) entity).build();
           crate.addDataEntity(dataEntity);
         } else {
           // here we have to think of a way to differentiate between data and contextual entities.
           var contextualEntity = new ContextualEntity.ContextualEntityBuilder()
-              .setAllIfValid((ObjectNode) entity).build();
+              .setAllUnsafe((ObjectNode) entity).build();
           crate.addContextualEntity(contextualEntity);
         }
       }

--- a/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/dataentities/ImportFromZenodo.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/dataentities/ImportFromZenodo.java
@@ -112,12 +112,12 @@ public class ImportFromZenodo {
       for (var entity : graph) {
         if (entity.get("@id").asText().equals(mainId)) {
           var dataEntity = new DataEntity.DataEntityBuilder()
-              .setAllUnsafe((ObjectNode) entity).build();
+              .setAllIfValid((ObjectNode) entity).build();
           crate.addDataEntity(dataEntity);
         } else {
           // here we have to think of a way to differentiate between data and contextual entities.
           var contextualEntity = new ContextualEntity.ContextualEntityBuilder()
-              .setAllUnsafe((ObjectNode) entity).build();
+              .setAllIfValid((ObjectNode) entity).build();
           crate.addContextualEntity(contextualEntity);
         }
       }

--- a/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/personprovider/OrcidProvider.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/personprovider/OrcidProvider.java
@@ -72,7 +72,7 @@ public class OrcidProvider {
           node.set(element.getKey(), element.getValue());
         }
       }
-      return new PersonEntity.PersonEntityBuilder().setAll(node).build();
+      return new PersonEntity.PersonEntityBuilder().setAllUnsafe(node).build();
     } catch (IOException e) {
       String errorMessage = String.format("IO error: %s", e.getMessage());
       logger.error(errorMessage);

--- a/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/personprovider/OrcidProvider.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/personprovider/OrcidProvider.java
@@ -72,7 +72,7 @@ public class OrcidProvider {
           node.set(element.getKey(), element.getValue());
         }
       }
-      return new PersonEntity.PersonEntityBuilder().setAllUnsafe(node).build();
+      return new PersonEntity.PersonEntityBuilder().setAllIfValid(node).build();
     } catch (IOException e) {
       String errorMessage = String.format("IO error: %s", e.getMessage());
       logger.error(errorMessage);

--- a/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/personprovider/OrcidProvider.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/externalproviders/personprovider/OrcidProvider.java
@@ -72,7 +72,7 @@ public class OrcidProvider {
           node.set(element.getKey(), element.getValue());
         }
       }
-      return new PersonEntity.PersonEntityBuilder().setAllIfValid(node).build();
+      return new PersonEntity.PersonEntityBuilder().setAllUnsafe(node).build();
     } catch (IOException e) {
       String errorMessage = String.format("IO error: %s", e.getMessage());
       logger.error(errorMessage);

--- a/src/main/java/edu/kit/datamanager/ro_crate/preview/AutomaticPreview.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/preview/AutomaticPreview.java
@@ -1,6 +1,6 @@
 package edu.kit.datamanager.ro_crate.preview;
 
-import edu.kit.datamanager.ro_crate.util.ZipUtil;
+import edu.kit.datamanager.ro_crate.util.ZipStreamUtil;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -10,9 +10,9 @@ import net.lingala.zip4j.io.outputstream.ZipOutputStream;
 import org.apache.commons.io.FileUtils;
 
 /**
- * The default preview should use the rochtml tool
- * (https://www.npmjs.com/package/ro-crate-html-js) for creating a simple
- * preview file.
+ * The default preview should use the
+ * <a href="https://www.npmjs.com/package/ro-crate-html-js">rochtml tool</a>
+ * for creating a simple preview file.
  *
  * @author Nikola Tzotchev on 6.2.2022 г.
  * @version 1
@@ -66,13 +66,13 @@ public class AutomaticPreview implements CratePreview {
         if (PreviewGenerator.isRochtmlAvailable()) {
             try {
                 FileUtils.forceMkdir(new File("temp"));
-                try (FileWriter writer = new FileWriter(new File("temp/ro-crate-metadata.json"))) {
+                try (FileWriter writer = new FileWriter("temp/ro-crate-metadata.json")) {
                     writer.write(metadata);
                     writer.flush();
                 }
                 if (PreviewGenerator.isRochtmlAvailable()) {
                     PreviewGenerator.generatePreview("temp");
-                    ZipUtil.addFileToZipStream(stream, new File("temp/ro-crate-preview.html"), "ro-crate-preview.html");
+                    ZipStreamUtil.addFileToZipStream(stream, new File("temp/ro-crate-preview.html"), "ro-crate-preview.html");
                 }
             } finally {
                 try {

--- a/src/main/java/edu/kit/datamanager/ro_crate/preview/CratePreview.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/preview/CratePreview.java
@@ -6,7 +6,7 @@ import java.nio.file.Files;
 
 import edu.kit.datamanager.ro_crate.Crate;
 import edu.kit.datamanager.ro_crate.writer.CrateWriter;
-import edu.kit.datamanager.ro_crate.writer.FolderStrategy;
+import edu.kit.datamanager.ro_crate.writer.WriteFolderStrategy;
 import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.io.outputstream.ZipOutputStream;
 import org.apache.commons.io.FileUtils;
@@ -38,7 +38,7 @@ public interface CratePreview {
         // disable preview generation to avoid recursion,
         // as this is usually called in the process of writing a crate
         // (including preview)
-        new CrateWriter<>(new FolderStrategy().disablePreview())
+        new CrateWriter<>(new WriteFolderStrategy().disablePreview())
                 .save(crate, targetDir.getAbsolutePath());
         this.saveAllToFolder(targetDir);
         try (var stream = Files.list(targetDir.toPath())) {

--- a/src/main/java/edu/kit/datamanager/ro_crate/preview/CratePreview.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/preview/CratePreview.java
@@ -2,8 +2,14 @@ package edu.kit.datamanager.ro_crate.preview;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+
+import edu.kit.datamanager.ro_crate.Crate;
+import edu.kit.datamanager.ro_crate.writer.CrateWriter;
+import edu.kit.datamanager.ro_crate.writer.FolderStrategy;
 import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.io.outputstream.ZipOutputStream;
+import org.apache.commons.io.FileUtils;
 
 /**
  * Interface for the ROCrate preview. This manages the human-readable
@@ -15,10 +21,77 @@ import net.lingala.zip4j.io.outputstream.ZipOutputStream;
  */
 public interface CratePreview {
 
+    /**
+     * Generate a preview of the crate and store it into the given target directory.
+     * It is the caller's responsibility to handle, e.g. delete after use, the result
+     * (The caller takes ownership of the result).
+     * <p>
+     * <b>IMPORTANT NOTE:</b> This method currently has a default implementation that relies
+     * on deprecated methods. In future, you will have to implement this method directly.
+     *
+     * @param crate the crate to generate a preview for.
+     * @param targetDir the target directory to store the preview in,
+     *                 owned by the caller.
+     * @throws IOException if an error occurs while generating the preview.
+     */
+    default void generate(Crate crate, File targetDir) throws IOException {
+        // disable preview generation to avoid recursion,
+        // as this is usually called in the process of writing a crate
+        // (including preview)
+        new CrateWriter<>(new FolderStrategy().disablePreview())
+                .save(crate, targetDir.getAbsolutePath());
+        this.saveAllToFolder(targetDir);
+        try (var stream = Files.list(targetDir.toPath())) {
+            stream
+                    .filter(path -> !path.getFileName().toString().equals("ro-crate-preview.html"))
+                    .filter(path -> !path.getFileName().toString().equals("ro-crate-preview_files"))
+                    .forEach(path -> {
+                        try {
+                            if (Files.isDirectory(path)) {
+                                FileUtils.deleteDirectory(path.toFile());
+                            } else {
+                                Files.delete(path);
+                            }
+                        } catch (IOException e) {
+                            // Silently ignore deletion errors
+                        }
+                    });
+        }
+    }
+
+    /**
+     * Takes a crate in form of a zip file and generates a preview of it,
+     * which will be stored within the crate.
+     *
+     * @param zipFile the zip file with the crate, which should receive a preview.
+     * @throws IOException if an error occurs while saving the preview
+     *
+     * @deprecated Use {@link #generate(Crate, File)} instead.
+     */
+    @Deprecated(since = "2.1.0", forRemoval = true)
     void saveAllToZip(ZipFile zipFile) throws IOException;
 
+    /**
+     * Saves the preview, given by the folder, into the given folder.
+     *
+     * @param folder the folder (containing a crate) to save the preview in.
+     * @throws IOException if an error occurs while saving the preview.
+     *
+     * @deprecated Use {@link #generate(Crate, File)} instead.
+     */
+    @Deprecated(since = "2.1.0", forRemoval = true)
     void saveAllToFolder(File folder) throws IOException;
-    
+
+    /**
+     * Saves the preview, given by the metadata, into the given stream.
+     *
+     * @param metadata the metadata of the crate to save the preview in.
+     * @param stream the stream to save the preview in.
+     * @throws IOException if an error occurs while saving the preview.
+     *
+     * @deprecated Use {@link #generate(Crate, File)} instead.
+     */
+    @Deprecated(since = "2.1.0", forRemoval = true)
     void saveAllToStream(String metadata, ZipOutputStream stream) throws IOException;
 
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/preview/CustomPreview.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/preview/CustomPreview.java
@@ -2,7 +2,7 @@ package edu.kit.datamanager.ro_crate.preview;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import edu.kit.datamanager.ro_crate.util.ZipUtil;
+import edu.kit.datamanager.ro_crate.util.ZipStreamUtil;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
@@ -53,7 +53,7 @@ public class CustomPreview implements CratePreview {
 
     private CustomPreviewModel mapFromJson(String metadata) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
-        JsonNode root = (JsonNode) mapper.readValue(metadata, JsonNode.class);
+        JsonNode root = mapper.readValue(metadata, JsonNode.class);
         JsonNode graph = root.get("@graph");
         CustomPreviewModel.ROCrate crate = new CustomPreviewModel.ROCrate();
         List<CustomPreviewModel.Dataset> datasets = new ArrayList<>();
@@ -196,13 +196,13 @@ public class CustomPreview implements CratePreview {
             //prepare output folder and writer
             FileUtils.forceMkdir(new File("temp"));
             //load and process template
-            try (FileWriter writer = new FileWriter(new File("temp/ro-crate-preview.html"))) {
+            try (FileWriter writer = new FileWriter("temp/ro-crate-preview.html")) {
                 //load and process template
                 template.process(dataModel, writer);
                 writer.flush();
             }
 
-            ZipUtil.addFileToZipStream(stream, new File("temp/ro-crate-preview.html"), "ro-crate-preview.html");
+            ZipStreamUtil.addFileToZipStream(stream, new File("temp/ro-crate-preview.html"), "ro-crate-preview.html");
         } catch (TemplateException ex) {
             throw new IOException("Failed to generate preview.", ex);
         } finally {

--- a/src/main/java/edu/kit/datamanager/ro_crate/preview/StaticPreview.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/preview/StaticPreview.java
@@ -1,6 +1,6 @@
 package edu.kit.datamanager.ro_crate.preview;
 
-import edu.kit.datamanager.ro_crate.util.ZipUtil;
+import edu.kit.datamanager.ro_crate.util.ZipStreamUtil;
 import java.io.File;
 import java.io.IOException;
 
@@ -64,9 +64,9 @@ public class StaticPreview implements CratePreview {
 
     @Override
     public void saveAllToStream(String metadata, ZipOutputStream stream) throws IOException {
-        ZipUtil.addFileToZipStream(stream, this.metadataHtml, "ro-crate-preview.html");
+        ZipStreamUtil.addFileToZipStream(stream, this.metadataHtml, "ro-crate-preview.html");
         if (this.otherFiles != null) {
-            ZipUtil.addFolderToZipStream(stream, this.otherFiles, "ro-crate-preview_files");
+            ZipStreamUtil.addFolderToZipStream(stream, this.otherFiles, "ro-crate-preview_files");
         }
     }
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/CrateReader.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/CrateReader.java
@@ -29,7 +29,7 @@ import java.util.stream.StreamSupport;
  * The constructor takes a strategy to support different ways of importing the
  * crates. (from zip, folder, etc.).
  * <p>
- * The reader consideres "hasPart" and "isPartOf" properties and considers all
+ * The reader considers "hasPart" and "isPartOf" properties and considers all
  * entities (in-)directly connected to the root entity ("./") as DataEntities.
  *
  * @param <T> the type of the location parameter

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/CrateReader.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/CrateReader.java
@@ -119,7 +119,7 @@ public class CrateReader<T> {
                     if (dataEntityIds.contains(eId)) {
                         // data entity
                         DataEntity.DataEntityBuilder dataEntity = new DataEntity.DataEntityBuilder()
-                                .setAll(entityJson.deepCopy());
+                                .setAllUnsafe(entityJson.deepCopy());
 
                         // Handle data entities with corresponding file
                         checkFolderHasFile(entityJson.get(PROP_ID).asText(), files).ifPresent(file -> {
@@ -133,7 +133,7 @@ public class CrateReader<T> {
                         // contextual entity
                         crate.addContextualEntity(
                                 new ContextualEntity.ContextualEntityBuilder()
-                                        .setAll(entityJson.deepCopy())
+                                        .setAllUnsafe(entityJson.deepCopy())
                                         .build());
                     }
                 }
@@ -255,7 +255,7 @@ public class CrateReader<T> {
 
                 crate.setRootDataEntity(
                         new RootDataEntity.RootDataEntityBuilder()
-                                .setAll(root.deepCopy())
+                                .setAllUnsafe(root.deepCopy())
                                 .setHasPart(hasPartIds)
                                 .build());
 
@@ -333,7 +333,7 @@ public class CrateReader<T> {
 
     private void setCrateDescriptor(RoCrate crate, JsonNode descriptor) {
         ContextualEntity descriptorEntity = new ContextualEntity.ContextualEntityBuilder()
-                .setAll(descriptor.deepCopy())
+                .setAllUnsafe(descriptor.deepCopy())
                 .build();
         crate.setJsonDescriptor(descriptorEntity);
     }

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/CrateReader.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/CrateReader.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -83,7 +84,7 @@ public class CrateReader<T> {
      * @param location the location of the ro-crate to be read
      * @return the read RO-crate
      */
-    public RoCrate readCrate(T location) {
+    public RoCrate readCrate(T location) throws IOException {
         // get the ro-crate-metadata.json
         ObjectNode metadataJson = strategy.readMetadataJson(location);
         // get the content of the crate

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/CrateReader.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/CrateReader.java
@@ -83,6 +83,8 @@ public class CrateReader<T> {
      *
      * @param location the location of the ro-crate to be read
      * @return the read RO-crate
+     *
+     * @throws IOException if the crate cannot be read
      */
     public RoCrate readCrate(T location) throws IOException {
         // get the ro-crate-metadata.json

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/FolderReader.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/FolderReader.java
@@ -6,7 +6,7 @@ package edu.kit.datamanager.ro_crate.reader;
  * @author Nikola Tzotchev on 9.2.2022 г.
  * @version 1
  *
- * @deprecated Use {@link FolderStrategy} instead.
+ * @deprecated Use {@link ReadFolderStrategy} instead.
  */
 @Deprecated(since = "2.1.0", forRemoval = true)
-public class FolderReader extends FolderStrategy {}
+public class FolderReader extends ReadFolderStrategy {}

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/FolderStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/FolderStrategy.java
@@ -17,15 +17,11 @@ import java.nio.file.Path;
 public class FolderStrategy implements GenericReaderStrategy<String> {
 
   @Override
-  public ObjectNode readMetadataJson(String location) {
+  public ObjectNode readMetadataJson(String location) throws IOException {
     Path metadata = new File(location).toPath().resolve("ro-crate-metadata.json");
     ObjectMapper objectMapper = MyObjectMapper.getMapper();
     ObjectNode objectNode = objectMapper.createObjectNode();
-    try {
-      objectNode = objectMapper.readTree(metadata.toFile()).deepCopy();
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
+    objectNode = objectMapper.readTree(metadata.toFile()).deepCopy();
     return objectNode;
   }
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/GenericReaderStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/GenericReaderStrategy.java
@@ -2,6 +2,7 @@ package edu.kit.datamanager.ro_crate.reader;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
+import java.io.IOException;
 
 /**
  * Generic interface for the strategy of the reader class.
@@ -16,7 +17,7 @@ public interface GenericReaderStrategy<T> {
      * @param location the location to read from
      * @return the parsed metadata.json as ObjectNode
      */
-    ObjectNode readMetadataJson(T location);
+    ObjectNode readMetadataJson(T location) throws IOException;
 
     /**
      * Read the content from the given location.
@@ -24,5 +25,5 @@ public interface GenericReaderStrategy<T> {
      * @param location the location to read from
      * @return the content as a File
      */
-    File readContent(T location);
+    File readContent(T location) throws IOException;
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/GenericReaderStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/GenericReaderStrategy.java
@@ -8,16 +8,16 @@ import java.io.IOException;
  * Generic interface for the strategy of the reader class.
  * This allows for flexible input types when implementing different reading strategies.
  *
- * @param <T> the type of the location parameter
+ * @param <SOURCE_TYPE> the type which determines the source of the crate
  */
-public interface GenericReaderStrategy<T> {
+public interface GenericReaderStrategy<SOURCE_TYPE> {
     /**
      * Read the metadata.json file from the given location.
      *
      * @param location the location to read from
      * @return the parsed metadata.json as ObjectNode
      */
-    ObjectNode readMetadataJson(T location) throws IOException;
+    ObjectNode readMetadataJson(SOURCE_TYPE location) throws IOException;
 
     /**
      * Read the content from the given location.
@@ -25,5 +25,5 @@ public interface GenericReaderStrategy<T> {
      * @param location the location to read from
      * @return the content as a File
      */
-    File readContent(T location) throws IOException;
+    File readContent(SOURCE_TYPE location) throws IOException;
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/ReadFolderStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/ReadFolderStrategy.java
@@ -14,7 +14,7 @@ import java.nio.file.Path;
  * @author Nikola Tzotchev on 9.2.2022 г.
  * @version 1
  */
-public class FolderStrategy implements GenericReaderStrategy<String> {
+public class ReadFolderStrategy implements GenericReaderStrategy<String> {
 
   @Override
   public ObjectNode readMetadataJson(String location) throws IOException {

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/ReadZipStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/ReadZipStrategy.java
@@ -29,7 +29,7 @@ import java.util.UUID;
  * persistent location and possibly read it from there, if required. Or use
  * the ZipWriter to write it back to its source.
  */
-public class ZipStrategy implements GenericReaderStrategy<String> {
+public class ReadZipStrategy implements GenericReaderStrategy<String> {
 
   protected final String ID = UUID.randomUUID().toString();
   protected Path temporaryFolder = Path.of(String.format("./.tmp/ro-crate-java/zipReader/%s/", ID));
@@ -38,7 +38,7 @@ public class ZipStrategy implements GenericReaderStrategy<String> {
   /**
    * Crates a ZipReader with the default configuration as described in the class documentation.
    */
-  public ZipStrategy() {}
+  public ReadZipStrategy() {}
 
   /**
    * Creates a ZipReader which will extract the contents temporary
@@ -51,7 +51,7 @@ public class ZipStrategy implements GenericReaderStrategy<String> {
    *                              directory. These subdirectories
    *                              will have UUIDs as their names.
    */
-  public ZipStrategy(Path folderPath, boolean shallAddUuidSubfolder) {
+  public ReadZipStrategy(Path folderPath, boolean shallAddUuidSubfolder) {
     if (shallAddUuidSubfolder) {
       this.temporaryFolder = folderPath.resolve(ID);
     } else {

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/ReadZipStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/ReadZipStrategy.java
@@ -14,11 +14,20 @@ import java.nio.file.Path;
 import java.util.UUID;
 
 /**
- * A ReaderStrategy implementation which reads from ZipFiles.
+ * Reads a crate from a ZIP archive (file).
  * <p>
- * May be used as a dependency for CrateReader. It will unzip
- * the ZipFile in a path relative to the directory this application runs in.
- * By default, it will be `./.tmp/ro-crate-java/zipReader/$UUID/`.
+ * This class handles reading and extraction of RO-Crate content from ZIP archives
+ * into a temporary directory structure on the file system,
+ * which allows accessing the contained files.
+ * <p>
+ * Supports <a href=https://github.com/TheELNConsortium/TheELNFileFormat>ELN-Style crates</a>,
+ * meaning the crate may be either in the zip archive directly or in a single,
+ * direct subfolder beneath the root folder (/folder).
+ * <p>
+ * Note: This implementation checks for up to 50 subdirectories if multiple are present.
+ * This is to avoid zip bombs, which may contain a lot of subdirectories,
+ * and at the same time gracefully handle valid crated with hidden subdirectories
+ * (for example, thumbnails).
  * <p>
  * NOTE: The resulting crate may refer to these temporary files. Therefore,
  * these files are only being deleted before the JVM exits. If you need to free
@@ -36,7 +45,10 @@ public class ReadZipStrategy implements GenericReaderStrategy<String> {
   protected boolean isExtracted = false;
 
   /**
-   * Crates a ZipReader with the default configuration as described in the class documentation.
+   * Crates an instance with the default configuration.
+   * <p>
+   * The default configuration is to extract the ZipFile to
+   * `./.tmp/ro-crate-java/zipReader/$UUID/`.
    */
   public ReadZipStrategy() {}
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/ReadZipStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/ReadZipStrategy.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import edu.kit.datamanager.ro_crate.entities.contextual.JsonDescriptor;
 import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
+import edu.kit.datamanager.ro_crate.util.FileSystemUtil;
 import net.lingala.zip4j.ZipFile;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.FileFilterUtils;
@@ -94,12 +95,7 @@ public class ReadZipStrategy implements GenericReaderStrategy<String> {
 
   private void readCrate(String location) throws IOException {
     File folder = temporaryFolder.toFile();
-    // ensure the directory is clean
-    if (folder.isDirectory()) {
-      FileUtils.cleanDirectory(folder);
-    } else if (folder.isFile()) {
-      FileUtils.delete(folder);
-    }
+    FileSystemUtil.mkdirOrDeleteContent(folder);
     // extract
     try (ZipFile zf = new ZipFile(location)) {
       zf.extractAll(temporaryFolder.toAbsolutePath().toString());

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/ReadZipStreamStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/ReadZipStreamStrategy.java
@@ -11,6 +11,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.UUID;
+
+import edu.kit.datamanager.ro_crate.util.FileSystemUtil;
 import net.lingala.zip4j.io.inputstream.ZipInputStream;
 import net.lingala.zip4j.model.LocalFileHeader;
 import org.apache.commons.io.FileUtils;
@@ -108,16 +110,7 @@ public class ReadZipStreamStrategy implements GenericReaderStrategy<InputStream>
      */
     private void readCrate(InputStream stream) throws IOException {
         File folder = temporaryFolder.toFile();
-        // ensure the directory is clean
-        if (folder.exists()) {
-            if (folder.isDirectory()) {
-                FileUtils.cleanDirectory(folder);
-            } else if (folder.isFile()) {
-                FileUtils.delete(folder);
-            }
-        } else {
-            FileUtils.forceMkdir(folder);
-        }
+        FileSystemUtil.mkdirOrDeleteContent(folder);
 
         LocalFileHeader localFileHeader;
         int readLen;

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/ReadZipStreamStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/ReadZipStreamStrategy.java
@@ -25,9 +25,9 @@ import org.slf4j.LoggerFactory;
  *
  * @author jejkal
  */
-public class ZipStreamStrategy implements GenericReaderStrategy<InputStream> {
+public class ReadZipStreamStrategy implements GenericReaderStrategy<InputStream> {
 
-    private static final Logger logger = LoggerFactory.getLogger(ZipStreamStrategy.class);
+    private static final Logger logger = LoggerFactory.getLogger(ReadZipStreamStrategy.class);
     protected final String ID = UUID.randomUUID().toString();
     protected Path temporaryFolder = Path.of(String.format("./.tmp/ro-crate-java/zipStreamReader/%s/", ID));
     protected boolean isExtracted = false;
@@ -36,7 +36,7 @@ public class ZipStreamStrategy implements GenericReaderStrategy<InputStream> {
      * Crates a ZipStreamReader with the default configuration as described in
      * the class documentation.
      */
-    public ZipStreamStrategy() {
+    public ReadZipStreamStrategy() {
     }
 
     /**
@@ -49,7 +49,7 @@ public class ZipStreamStrategy implements GenericReaderStrategy<InputStream> {
      * subdirectories of the given directory. These subdirectories will have
      * UUIDs as their names.
      */
-    public ZipStreamStrategy(Path folderPath, boolean shallAddUuidSubfolder) {
+    public ReadZipStreamStrategy(Path folderPath, boolean shallAddUuidSubfolder) {
         if (shallAddUuidSubfolder) {
             this.temporaryFolder = folderPath.resolve(ID);
         } else {

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/Readers.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/Readers.java
@@ -19,10 +19,10 @@ public class Readers {
      *
      * @return A reader configured for ZIP files
      *
-     * @see ZipStreamStrategy#ZipStreamStrategy()
+     * @see ReadZipStreamStrategy#ReadZipStreamStrategy()
      */
     public static CrateReader<InputStream> newZipStreamReader() {
-        return new CrateReader<>(new ZipStreamStrategy());
+        return new CrateReader<>(new ReadZipStreamStrategy());
     }
 
     /**
@@ -33,10 +33,10 @@ public class Readers {
      * @param useUuidSubfolder Whether to create a UUID subfolder under extractPath
      * @return A reader configured for ZIP files with custom extraction
      *
-     * @see ZipStreamStrategy#ZipStreamStrategy(Path, boolean)
+     * @see ReadZipStreamStrategy#ReadZipStreamStrategy(Path, boolean)
      */
     public static CrateReader<InputStream> newZipStreamReader(Path extractPath, boolean useUuidSubfolder) {
-        return new CrateReader<>(new ZipStreamStrategy(extractPath, useUuidSubfolder));
+        return new CrateReader<>(new ReadZipStreamStrategy(extractPath, useUuidSubfolder));
     }
 
     /**
@@ -44,10 +44,10 @@ public class Readers {
      *
      * @return A reader configured for folders
      *
-     * @see FolderStrategy
+     * @see ReadFolderStrategy
      */
     public static CrateReader<String> newFolderReader() {
-        return new CrateReader<>(new FolderStrategy());
+        return new CrateReader<>(new ReadFolderStrategy());
     }
 
     /**
@@ -55,10 +55,10 @@ public class Readers {
      *
      * @return A reader configured for ZIP files
      *
-     * @see ZipStrategy#ZipStrategy()
+     * @see ReadZipStrategy#ReadZipStrategy()
      */
     public static CrateReader<String> newZipPathReader() {
-        return new CrateReader<>(new ZipStrategy());
+        return new CrateReader<>(new ReadZipStrategy());
     }
 
     /**
@@ -69,9 +69,9 @@ public class Readers {
      * @param useUuidSubfolder Whether to create a UUID subfolder under extractPath
      * @return A reader configured for ZIP files with custom extraction
      *
-     * @see ZipStrategy#ZipStrategy(Path, boolean)
+     * @see ReadZipStrategy#ReadZipStrategy(Path, boolean)
      */
     public static CrateReader<String> newZipPathReader(Path extractPath, boolean useUuidSubfolder) {
-        return new CrateReader<>(new ZipStrategy(extractPath, useUuidSubfolder));
+        return new CrateReader<>(new ReadZipStrategy(extractPath, useUuidSubfolder));
     }
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/ZipReader.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/ZipReader.java
@@ -18,10 +18,10 @@ import java.nio.file.Path;
  * persistent location and possibly read it from there, if required. Or use
  * the ZipWriter to write it back to its source.
  *
- * @deprecated Use {@link ZipStrategy} instead.
+ * @deprecated Use {@link ReadZipStrategy} instead.
  */
 @Deprecated(since = "2.1.0", forRemoval = true)
-public class ZipReader extends ZipStrategy {
+public class ZipReader extends ReadZipStrategy {
 
   /**
    * Crates a ZipReader with the default configuration as described in the class documentation.

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/ZipStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/ZipStrategy.java
@@ -6,6 +6,7 @@ import edu.kit.datamanager.ro_crate.entities.contextual.JsonDescriptor;
 import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
 import net.lingala.zip4j.ZipFile;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.FileFilterUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -110,12 +111,16 @@ public class ZipStrategy implements GenericReaderStrategy<String> {
     File jsonMetadata = this.temporaryFolder.resolve(JsonDescriptor.ID).toFile();
     if (!jsonMetadata.isFile()) {
       // Try to find the metadata file in subdirectories
-      File firstSubdir = FileUtils.listFilesAndDirs(temporaryFolder.toFile(), null, null)
-          .stream()
-          .limit(50)
-          .filter(file -> file.toPath().toAbsolutePath().resolve(JsonDescriptor.ID).toFile().isFile())
-          .findFirst()
-          .orElseThrow(() -> new IllegalStateException("No %s found in zip file".formatted(JsonDescriptor.ID)));
+      File firstSubdir = FileUtils.listFilesAndDirs(
+            temporaryFolder.toFile(),
+            FileFilterUtils.directoryFileFilter(),
+            null // not recursive
+        )
+        .stream()
+        .limit(50)
+        .filter(file -> file.toPath().toAbsolutePath().resolve(JsonDescriptor.ID).toFile().isFile())
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("No %s found in zip file".formatted(JsonDescriptor.ID)));
       jsonMetadata = firstSubdir.toPath().resolve(JsonDescriptor.ID).toFile();
     }
     

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/ZipStreamStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/ZipStreamStrategy.java
@@ -110,6 +110,11 @@ public class ZipStreamStrategy implements GenericReaderStrategy<InputStream> {
                     if (!extractedFile.toPath().startsWith(folder.getCanonicalPath())) {
                         throw new IOException("Entry is outside of target directory: " + fileName);
                     }
+                    if (localFileHeader.isDirectory()) {
+                        FileUtils.forceMkdir(extractedFile);
+                        continue;
+                    }
+                    FileUtils.forceMkdir(extractedFile.getParentFile());
                     try (OutputStream outputStream = new FileOutputStream(extractedFile)) {
                         while ((readLen = zipInputStream.read(readBuffer)) != -1) {
                             outputStream.write(readBuffer, 0, readLen);

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/ZipStreamStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/ZipStreamStrategy.java
@@ -4,14 +4,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import edu.kit.datamanager.ro_crate.entities.contextual.JsonDescriptor;
 import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
-
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-import java.util.Enumeration;
 import java.util.UUID;
-
-import org.apache.commons.compress.archivers.zip.*;
+import net.lingala.zip4j.io.inputstream.ZipInputStream;
+import net.lingala.zip4j.model.LocalFileHeader;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.slf4j.Logger;
@@ -98,27 +99,26 @@ public class ZipStreamStrategy implements GenericReaderStrategy<InputStream> {
                 FileUtils.forceMkdir(folder);
             }
 
+            LocalFileHeader localFileHeader;
+            int readLen;
+            byte[] readBuffer = new byte[4096];
 
-            ZipFile.Builder zipFileBuilder = new ZipFile.Builder()
-                    .setByteArray(stream.readAllBytes())
-                    .setIgnoreLocalFileHeader(true)
-                    .setOpenOptions(StandardOpenOption.READ);
-            try (ZipFile zipFile = zipFileBuilder.get()) {
-                Enumeration<ZipArchiveEntry> filesInZip = zipFile.getEntries();
-                while (filesInZip.hasMoreElements()) {
-                    ZipArchiveEntry entry = filesInZip.nextElement();
-                    String fileName = entry.getName();
+            try (ZipInputStream zipInputStream = new ZipInputStream(stream)) {
+                while ((localFileHeader = zipInputStream.getNextEntry()) != null) {
+                    String fileName = localFileHeader.getFileName();
                     File extractedFile = new File(folder, fileName).getCanonicalFile();
                     if (!extractedFile.toPath().startsWith(folder.getCanonicalPath())) {
                         throw new IOException("Entry is outside of target directory: " + fileName);
                     }
-                    if (entry.isDirectory()) {
+                    if (localFileHeader.isDirectory()) {
                         FileUtils.forceMkdir(extractedFile);
                         continue;
                     }
                     FileUtils.forceMkdir(extractedFile.getParentFile());
                     try (OutputStream outputStream = new FileOutputStream(extractedFile)) {
-                        zipFile.getInputStream(entry).transferTo(outputStream);
+                        while ((readLen = zipInputStream.read(readBuffer)) != -1) {
+                            outputStream.write(readBuffer, 0, readLen);
+                        }
                     }
                 }
             }

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/ZipStreamStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/ZipStreamStrategy.java
@@ -2,6 +2,7 @@ package edu.kit.datamanager.ro_crate.reader;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import edu.kit.datamanager.ro_crate.entities.contextual.JsonDescriptor;
 import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -13,6 +14,7 @@ import java.util.UUID;
 import net.lingala.zip4j.io.inputstream.ZipInputStream;
 import net.lingala.zip4j.model.LocalFileHeader;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -130,7 +132,21 @@ public class ZipStreamStrategy implements GenericReaderStrategy<InputStream> {
         }
 
         ObjectMapper objectMapper = MyObjectMapper.getMapper();
-        File jsonMetadata = temporaryFolder.resolve("ro-crate-metadata.json").toFile();
+        File jsonMetadata = temporaryFolder.resolve(JsonDescriptor.ID).toFile();
+        if (!jsonMetadata.isFile()) {
+            // Try to find the metadata file in subdirectories
+            File firstSubdir = FileUtils.listFilesAndDirs(
+                            temporaryFolder.toFile(),
+                            FileFilterUtils.directoryFileFilter(),
+                            null
+                    )
+                    .stream()
+                    .limit(50)
+                    .filter(file -> file.toPath().toAbsolutePath().resolve(JsonDescriptor.ID).toFile().isFile())
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("No %s found in zip file".formatted(JsonDescriptor.ID)));
+            jsonMetadata = firstSubdir.toPath().resolve(JsonDescriptor.ID).toFile();
+        }
 
         try {
             return objectMapper.readTree(jsonMetadata).deepCopy();

--- a/src/main/java/edu/kit/datamanager/ro_crate/util/FileSystemUtil.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/util/FileSystemUtil.java
@@ -1,6 +1,11 @@
 package edu.kit.datamanager.ro_crate.util;
 
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.regex.Matcher;
 
 public class FileSystemUtil {
@@ -44,5 +49,24 @@ public class FileSystemUtil {
             return path + "/";
         }
         return path;
+    }
+
+    /**
+     * Creates a directory or deletes its content if it already exists.
+     *
+     * @param folder the folder to create or delete content from
+     * @throws IOException if an I/O error occurs
+     */
+    public static void mkdirOrDeleteContent(File folder) throws IOException {
+        boolean isNonEmptyDir = folder.exists()
+                && folder.isDirectory()
+                && Objects.requireNonNull(folder.listFiles()).length > 0;
+        boolean isFile = folder.exists()
+                && !folder.isDirectory();
+
+        if (isNonEmptyDir || isFile) {
+            FileUtils.forceDelete(folder);
+        }
+        FileUtils.forceMkdir(folder);
     }
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/util/FileSystemUtil.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/util/FileSystemUtil.java
@@ -1,0 +1,48 @@
+package edu.kit.datamanager.ro_crate.util;
+
+import java.util.Collection;
+import java.util.regex.Matcher;
+
+public class FileSystemUtil {
+    private FileSystemUtil() {
+        // Utility class, no instantiation
+    }
+
+    /**
+     * Removes a specific set of given file extensions from a file name, if present.
+     * The extensions are case-insensitive. Given "ELN", "eln" or "Eln" will also match.
+     * The dot (.) before the extension is also assumed and removed implicitly:
+     * <p>
+     * Example:
+     * filterExtensionsFromFileName("test.eln", Set.of("ELN")) -> "test"
+     *
+     * @param filename the file name to filter
+     * @param extensionsToRemove the extensions to remove
+     * @return the filtered file name
+     */
+    public static String filterExtensionsFromFileName(String filename, Collection<String> extensionsToRemove) {
+        String dot = Matcher.quoteReplacement(".");
+        String end = Matcher.quoteReplacement("$");
+        for (String extension : extensionsToRemove) {
+            // (?i) removes case sensitivity
+            filename = filename.replaceFirst("(?i)" + dot + extension + end, "");
+        }
+        return filename;
+    }
+
+    /**
+     * Ensures that a given path ends with a trailing slash.
+     *
+     * @param path the path to check
+     * @return the path with a trailing slash if it didn't have one, or the original path
+     */
+    public static String ensureTrailingSlash(String path) {
+        if (path == null || path.isEmpty()) {
+            return path;
+        }
+        if (!path.endsWith("/")) {
+            return path + "/";
+        }
+        return path;
+    }
+}

--- a/src/main/java/edu/kit/datamanager/ro_crate/util/ZipStreamUtil.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/util/ZipStreamUtil.java
@@ -11,7 +11,7 @@ import net.lingala.zip4j.model.ZipParameters;
  *
  * @author jejkal
  */
-public class ZipUtil {
+public class ZipStreamUtil {
 
     /**
      * Adds a folder and its contents to a ZipOutputStream.

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/CrateWriter.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/CrateWriter.java
@@ -10,11 +10,11 @@ import java.io.IOException;
  * The class used for writing (exporting) crates. The class uses a strategy
  * pattern for writing crates as different formats. (zip, folders, etc.)
  */
-public class CrateWriter<DESTINATION> {
+public class CrateWriter<DESTINATION_TYPE> {
 
-    private final GenericWriterStrategy<DESTINATION> strategy;
+    private final GenericWriterStrategy<DESTINATION_TYPE> strategy;
 
-    public CrateWriter(GenericWriterStrategy<DESTINATION> strategy) {
+    public CrateWriter(GenericWriterStrategy<DESTINATION_TYPE> strategy) {
         this.strategy = strategy;
     }
 
@@ -24,7 +24,7 @@ public class CrateWriter<DESTINATION> {
      * @param crate the crate to write.
      * @param destination the location where the crate should be written.
      */
-    public void save(Crate crate, DESTINATION destination) throws IOException {
+    public void save(Crate crate, DESTINATION_TYPE destination) throws IOException {
         Validator defaultValidation = new Validator(new JsonSchemaValidation());
         defaultValidation.validate(crate);
         this.strategy.save(crate, destination);

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/CrateWriter.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/CrateWriter.java
@@ -4,6 +4,8 @@ import edu.kit.datamanager.ro_crate.Crate;
 import edu.kit.datamanager.ro_crate.validation.JsonSchemaValidation;
 import edu.kit.datamanager.ro_crate.validation.Validator;
 
+import java.io.IOException;
+
 /**
  * The class used for writing (exporting) crates. The class uses a strategy
  * pattern for writing crates as different formats. (zip, folders, etc.)
@@ -22,7 +24,7 @@ public class CrateWriter<DESTINATION> {
      * @param crate the crate to write.
      * @param destination the location where the crate should be written.
      */
-    public void save(Crate crate, DESTINATION destination) {
+    public void save(Crate crate, DESTINATION destination) throws IOException {
         Validator defaultValidation = new Validator(new JsonSchemaValidation());
         defaultValidation.validate(crate);
         this.strategy.save(crate, destination);

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/CrateWriter.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/CrateWriter.java
@@ -9,6 +9,8 @@ import java.io.IOException;
 /**
  * The class used for writing (exporting) crates. The class uses a strategy
  * pattern for writing crates as different formats. (zip, folders, etc.)
+ *
+ * @param <DESTINATION_TYPE> the type which determines the destination of the result
  */
 public class CrateWriter<DESTINATION_TYPE> {
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/ElnFormatWriter.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/ElnFormatWriter.java
@@ -1,6 +1,12 @@
 package edu.kit.datamanager.ro_crate.writer;
 
-public interface ElnFormatWriter<SOURCE_TYPE> extends GenericWriterStrategy<SOURCE_TYPE> {
+/**
+ * An Interface for {@link GenericWriterStrategy} implementations which support writing
+ * <a href=https://github.com/TheELNConsortium/TheELNFileFormat>ELN-Style crates</a>.
+ *
+ * @param <DESTINATION_TYPE> the type which determines the destination of the result
+ */
+public interface ElnFormatWriter<DESTINATION_TYPE> extends GenericWriterStrategy<DESTINATION_TYPE> {
 
     /**
      * Write in ELN format style, meaning with a root subfolder in the zip file.
@@ -8,14 +14,14 @@ public interface ElnFormatWriter<SOURCE_TYPE> extends GenericWriterStrategy<SOUR
      *
      * @return this writer
      */
-    ElnFormatWriter<SOURCE_TYPE> usingElnStyle();
+    ElnFormatWriter<DESTINATION_TYPE> usingElnStyle();
 
     /**
      * Alias with more generic name for {@link #usingElnStyle()}.
      *
      * @return this writer
      */
-    default ElnFormatWriter<SOURCE_TYPE> withRootSubdirectory() {
+    default ElnFormatWriter<DESTINATION_TYPE> withRootSubdirectory() {
         return this.usingElnStyle();
     }
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/ElnFormatWriter.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/ElnFormatWriter.java
@@ -1,21 +1,15 @@
 package edu.kit.datamanager.ro_crate.writer;
 
-import java.io.IOException;
-
 public interface ElnFormatWriter<SOURCE_TYPE> extends GenericWriterStrategy<SOURCE_TYPE> {
 
     /**
      * Write in ELN format style, meaning with a root subfolder in the zip file.
      * Same as {@link #withRootSubdirectory()}.
-     *
-     * @throws IOException if an error occurs
      */
     ElnFormatWriter<SOURCE_TYPE> usingElnStyle();
 
     /**
      * Alias with more generic name for {@link #usingElnStyle()}.
-     *
-     * @throws IOException if an error occurs
      */
     default ElnFormatWriter<SOURCE_TYPE> withRootSubdirectory() {
         return this.usingElnStyle();

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/ElnFormatWriter.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/ElnFormatWriter.java
@@ -5,11 +5,15 @@ public interface ElnFormatWriter<SOURCE_TYPE> extends GenericWriterStrategy<SOUR
     /**
      * Write in ELN format style, meaning with a root subfolder in the zip file.
      * Same as {@link #withRootSubdirectory()}.
+     *
+     * @return this writer
      */
     ElnFormatWriter<SOURCE_TYPE> usingElnStyle();
 
     /**
      * Alias with more generic name for {@link #usingElnStyle()}.
+     *
+     * @return this writer
      */
     default ElnFormatWriter<SOURCE_TYPE> withRootSubdirectory() {
         return this.usingElnStyle();

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/ElnFormatWriter.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/ElnFormatWriter.java
@@ -1,0 +1,23 @@
+package edu.kit.datamanager.ro_crate.writer;
+
+import java.io.IOException;
+
+public interface ElnFormatWriter<SOURCE_TYPE> extends GenericWriterStrategy<SOURCE_TYPE> {
+
+    /**
+     * Write in ELN format style, meaning with a root subfolder in the zip file.
+     * Same as {@link #withRootSubdirectory()}.
+     *
+     * @throws IOException if an error occurs
+     */
+    ElnFormatWriter<SOURCE_TYPE> usingElnStyle();
+
+    /**
+     * Alias with more generic name for {@link #usingElnStyle()}.
+     *
+     * @throws IOException if an error occurs
+     */
+    default ElnFormatWriter<SOURCE_TYPE> withRootSubdirectory() {
+        return this.usingElnStyle();
+    }
+}

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/FolderStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/FolderStrategy.java
@@ -25,6 +25,21 @@ public class FolderStrategy implements GenericWriterStrategy<String> {
 
     private static final Logger logger = LoggerFactory.getLogger(FolderStrategy.class);
 
+    protected boolean writePreview = true;
+
+    /**
+     * For internal use. Skips the preview generation when writing the crate.
+     *
+     * @return this instance of FolderStrategy
+     *
+     * @deprecated May be removed in future versions. Not intended for public use.
+     */
+    @Deprecated(since = "2.1.0", forRemoval = true)
+    public FolderStrategy disablePreview() {
+        this.writePreview = false;
+        return this;
+    }
+
     @Override
     public void save(Crate crate, String destination) throws IOException {
         File file = new File(destination);
@@ -38,7 +53,7 @@ public class FolderStrategy implements GenericWriterStrategy<String> {
         FileUtils.copyInputStreamToFile(inputStream, json);
         inputStream.close();
         // save also the preview files to the crate destination
-        if (crate.getPreview() != null) {
+        if (crate.getPreview() != null && this.writePreview) {
             crate.getPreview().saveAllToFolder(file);
         }
         for (var e : crate.getUntrackedFiles()) {

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/FolderStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/FolderStrategy.java
@@ -49,7 +49,17 @@ public class FolderStrategy implements GenericWriterStrategy<String> {
             }
         }
         for (DataEntity dataEntity : crate.getAllDataEntities()) {
-            dataEntity.savetoFile(file);
+            savetoFile(dataEntity, file);
+        }
+    }
+
+    private void savetoFile(DataEntity entity, File file) throws IOException {
+        if (entity.getPath() != null) {
+            if (entity.getPath().toFile().isDirectory()) {
+                FileUtils.copyDirectory(entity.getPath().toFile(), file.toPath().resolve(entity.getId()).toFile());
+            } else {
+                FileUtils.copyFile(entity.getPath().toFile(), file.toPath().resolve(entity.getId()).toFile());
+            }
         }
     }
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/FolderWriter.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/FolderWriter.java
@@ -5,7 +5,7 @@ package edu.kit.datamanager.ro_crate.writer;
  *
  * @author Nikola Tzotchev on 9.2.2022 г.
  *
- * @deprecated Use {@link FolderStrategy} instead.
+ * @deprecated Use {@link WriteFolderStrategy} instead.
  */
 @Deprecated(since = "2.1.0", forRemoval = true)
-public class FolderWriter extends FolderStrategy {}
+public class FolderWriter extends WriteFolderStrategy {}

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/GenericWriterStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/GenericWriterStrategy.java
@@ -2,6 +2,8 @@ package edu.kit.datamanager.ro_crate.writer;
 
 import edu.kit.datamanager.ro_crate.Crate;
 
+import java.io.IOException;
+
 /**
  * Generic interface for the strategy of the writer class.
  * This allows for flexible output types when implementing different writing strategies.
@@ -15,5 +17,5 @@ public interface GenericWriterStrategy<DESTINATION> {
      * @param crate       The crate to save
      * @param destination The destination where the crate should be saved
      */
-    void save(Crate crate, DESTINATION destination);
+    void save(Crate crate, DESTINATION destination) throws IOException;
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/GenericWriterStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/GenericWriterStrategy.java
@@ -8,14 +8,14 @@ import java.io.IOException;
  * Generic interface for the strategy of the writer class.
  * This allows for flexible output types when implementing different writing strategies.
  *
- * @param <DESTINATION> the type of the destination parameter
+ * @param <DESTINATION_TYPE> the type of the destination parameter
  */
-public interface GenericWriterStrategy<DESTINATION> {
+public interface GenericWriterStrategy<DESTINATION_TYPE> {
     /**
      * Saves the given crate to the specified destination.
      *
      * @param crate       The crate to save
      * @param destination The destination where the crate should be saved
      */
-    void save(Crate crate, DESTINATION destination) throws IOException;
+    void save(Crate crate, DESTINATION_TYPE destination) throws IOException;
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/WriteFolderStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/WriteFolderStrategy.java
@@ -21,21 +21,21 @@ import java.nio.charset.StandardCharsets;
  * @author Nikola Tzotchev on 9.2.2022 г.
  * @version 1
  */
-public class FolderStrategy implements GenericWriterStrategy<String> {
+public class WriteFolderStrategy implements GenericWriterStrategy<String> {
 
-    private static final Logger logger = LoggerFactory.getLogger(FolderStrategy.class);
+    private static final Logger logger = LoggerFactory.getLogger(WriteFolderStrategy.class);
 
     protected boolean writePreview = true;
 
     /**
      * For internal use. Skips the preview generation when writing the crate.
      *
-     * @return this instance of FolderStrategy
+     * @return this instance of WriteFolderStrategy
      *
      * @deprecated May be removed in future versions. Not intended for public use.
      */
     @Deprecated(since = "2.1.0", forRemoval = true)
-    public FolderStrategy disablePreview() {
+    public WriteFolderStrategy disablePreview() {
         this.writePreview = false;
         return this;
     }

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/WriteZipStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/WriteZipStrategy.java
@@ -6,6 +6,7 @@ import edu.kit.datamanager.ro_crate.Crate;
 import edu.kit.datamanager.ro_crate.entities.data.DataEntity;
 import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
 import edu.kit.datamanager.ro_crate.preview.CratePreview;
+import edu.kit.datamanager.ro_crate.util.FileSystemUtil;
 import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.model.ZipParameters;
 import org.apache.commons.io.FileUtils;
@@ -19,8 +20,8 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
-import java.util.regex.Matcher;
 
 /**
  * Implementation of the writing strategy to provide a way of writing crates to
@@ -31,6 +32,7 @@ public class WriteZipStrategy implements
         ElnFormatWriter<String>
 {
     private static final Logger logger = LoggerFactory.getLogger(WriteZipStrategy.class);
+    public static final String TMP_DIR = "./.tmp/ro-crate-java/writer-zip-strategy/";
 
     /**
      * Defines if the zip file will directly contain the crate,
@@ -48,17 +50,10 @@ public class WriteZipStrategy implements
     public void save(Crate crate, String destination) throws IOException {
         String innerFolderName = "";
         if (this.createRootSubdir) {
-            String dot = Matcher.quoteReplacement(".");
-            String end = Matcher.quoteReplacement("$");
-            innerFolderName = Path.of(destination).getFileName()
-                    .toString()
-                    // remove .zip or .eln from the end of the file name
-                    // (?i) removes case sensitivity
-                    .replaceFirst("(?i)" + dot + "zip" + end, "")
-                    .replaceFirst("(?i)" + dot + "eln" + end, "");
-            if (!innerFolderName.endsWith("/")) {
-                innerFolderName += "/";
-            }
+            innerFolderName = FileSystemUtil.filterExtensionsFromFileName(
+                    Path.of(destination).getFileName().toString(),
+                    Set.of("ELN", "ZIP"));
+            innerFolderName = FileSystemUtil.ensureTrailingSlash(innerFolderName);
         }
         try (ZipFile zipFile = new ZipFile(destination)) {
             saveMetadataJson(crate, zipFile, innerFolderName);
@@ -93,7 +88,7 @@ public class WriteZipStrategy implements
             return;
         }
         final String ID = UUID.randomUUID().toString();
-        File tmpPreviewFolder = Path.of("./.tmp/ro-crate-java/writer-zipStrategy/")
+        File tmpPreviewFolder = Path.of(TMP_DIR)
                 .resolve(ID)
                 .toFile();
         FileUtils.forceMkdir(tmpPreviewFolder);
@@ -102,7 +97,7 @@ public class WriteZipStrategy implements
         preview.get().generate(crate, tmpPreviewFolder);
         String[] paths = tmpPreviewFolder.list();
         if (paths == null) {
-            throw new IOException("No files found in temporary folder");
+            throw new IOException("No preview files found in temporary folder. Preview generation failed.");
         }
         for (String path : paths) {
             File file = tmpPreviewFolder.toPath().resolve(path).toFile();

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/WriteZipStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/WriteZipStrategy.java
@@ -2,71 +2,56 @@ package edu.kit.datamanager.ro_crate.writer;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import edu.kit.datamanager.ro_crate.Crate;
 import edu.kit.datamanager.ro_crate.entities.data.DataEntity;
 import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
+import edu.kit.datamanager.ro_crate.preview.CratePreview;
+import net.lingala.zip4j.ZipFile;
+import net.lingala.zip4j.model.ZipParameters;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Matcher;
 
-import edu.kit.datamanager.ro_crate.preview.CratePreview;
-import edu.kit.datamanager.ro_crate.util.ZipUtil;
-import net.lingala.zip4j.io.outputstream.ZipOutputStream;
-import net.lingala.zip4j.model.ZipParameters;
-import org.apache.commons.io.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Implementation of the writing strategy to provide a way of writing crates to
  * a zip archive.
  */
-public class ZipStreamStrategy implements
-        GenericWriterStrategy<OutputStream>,
-        ElnFormatWriter<OutputStream> {
-
-    private static final Logger logger = LoggerFactory.getLogger(ZipStreamStrategy.class);
+public class WriteZipStrategy implements
+        GenericWriterStrategy<String>,
+        ElnFormatWriter<String>
+{
+    private static final Logger logger = LoggerFactory.getLogger(WriteZipStrategy.class);
 
     /**
      * Defines if the zip file will directly contain the crate,
      * or if it will contain a subdirectory with the crate.
      */
     protected boolean createRootSubdir = false;
-    protected String rootSubdirName = "content";
 
     @Override
-    public ElnFormatWriter<OutputStream> usingElnStyle() {
-        this.createRootSubdir = true;
-        return this;
-    }
-
-    /**
-     * Sets the name of a root subdirectory in the zip file.
-     * Implicitly also enables the creation of a root subdirectory.
-     * If used for ELN files, note the subdirectory name should be the same as the zip
-     * files name.
-     *
-     * @param name the name of the subdirectory
-     * @return this instance of ZipStreamStrategy
-     */
-    public ZipStreamStrategy setSubdirectoryName(String name) {
-        this.rootSubdirName = name;
+    public ElnFormatWriter<String> usingElnStyle() {
         this.createRootSubdir = true;
         return this;
     }
 
     @Override
-    public void save(Crate crate, OutputStream destination) throws IOException {
+    public void save(Crate crate, String destination) throws IOException {
         String innerFolderName = "";
         if (this.createRootSubdir) {
             String dot = Matcher.quoteReplacement(".");
             String end = Matcher.quoteReplacement("$");
-            innerFolderName = this.rootSubdirName
+            innerFolderName = Path.of(destination).getFileName()
+                    .toString()
                     // remove .zip or .eln from the end of the file name
                     // (?i) removes case sensitivity
                     .replaceFirst("(?i)" + dot + "zip" + end, "")
@@ -75,20 +60,20 @@ public class ZipStreamStrategy implements
                 innerFolderName += "/";
             }
         }
-        try (ZipOutputStream zipFile = new ZipOutputStream(destination)) {
+        try (ZipFile zipFile = new ZipFile(destination)) {
             saveMetadataJson(crate, zipFile, innerFolderName);
             saveDataEntities(crate, zipFile, innerFolderName);
             savePreview(crate, zipFile, innerFolderName);
         }
     }
 
-    private void saveDataEntities(Crate crate, ZipOutputStream zipStream, String prefix) throws IOException {
+    private void saveDataEntities(Crate crate, ZipFile zipFile, String prefix) throws IOException {
         for (DataEntity dataEntity : crate.getAllDataEntities()) {
-            this.saveToStream(dataEntity, zipStream, prefix);
+            this.saveToZip(dataEntity, zipFile, prefix);
         }
     }
 
-    private void saveMetadataJson(Crate crate, ZipOutputStream zipStream, String prefix) throws IOException {
+    private void saveMetadataJson(Crate crate, ZipFile zipFile, String prefix) throws IOException {
         // write the metadata.json file
         ZipParameters zipParameters = new ZipParameters();
         zipParameters.setFileNameInZip(prefix + "ro-crate-metadata.json");
@@ -96,20 +81,13 @@ public class ZipStreamStrategy implements
         // we create an JsonNode only to have the file written pretty
         JsonNode node = objectMapper.readTree(crate.getJsonMetadata());
         String str = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(node);
-        // write the ro-crate-metadata
-
-        byte[] buff = new byte[4096];
-        int readLen;
-        zipStream.putNextEntry(zipParameters);
         try (InputStream inputStream = new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8))) {
-            while ((readLen = inputStream.read(buff)) != -1) {
-                zipStream.write(buff, 0, readLen);
-            }
+            // write the ro-crate-metadata
+            zipFile.addStream(inputStream, zipParameters);
         }
-        zipStream.closeEntry();
     }
 
-    private void savePreview(Crate crate, ZipOutputStream zipStream, String prefix) throws IOException {
+    private void savePreview(Crate crate, ZipFile zipFile, String prefix) throws IOException {
         Optional<CratePreview> preview = Optional.ofNullable(crate.getPreview());
         if (preview.isEmpty()) {
             return;
@@ -129,15 +107,14 @@ public class ZipStreamStrategy implements
         for (String path : paths) {
             File file = tmpPreviewFolder.toPath().resolve(path).toFile();
             if (file.isDirectory()) {
-                ZipUtil.addFolderToZipStream(
-                        zipStream,
-                        file,
-                        prefix + path);
+                ZipParameters parameters = new ZipParameters();
+                parameters.setRootFolderNameInZip(prefix + path);
+                parameters.setIncludeRootFolder(false);
+                zipFile.addFolder(file, parameters);
             } else {
-                ZipUtil.addFileToZipStream(
-                        zipStream,
-                        file,
-                        prefix + path);
+                ZipParameters zipParameters = new ZipParameters();
+                zipParameters.setFileNameInZip(prefix + path);
+                zipFile.addFile(file, zipParameters);
             }
         }
         try {
@@ -147,22 +124,21 @@ public class ZipStreamStrategy implements
         }
     }
 
-    private void saveToStream(DataEntity entity, ZipOutputStream zipStream, String prefix) throws IOException {
-        if (entity == null) {
+    private void saveToZip(DataEntity entity, ZipFile zipFile, String prefix) throws IOException {
+        if (entity == null || entity.getPath() == null) {
             return;
         }
 
         boolean isDirectory = entity.getPath().toFile().isDirectory();
         if (isDirectory) {
-            ZipUtil.addFolderToZipStream(
-                    zipStream,
-                    entity.getPath().toAbsolutePath().toString(),
-                    prefix + entity.getId());
+            ZipParameters parameters = new ZipParameters();
+            parameters.setRootFolderNameInZip(prefix + entity.getId());
+            parameters.setIncludeRootFolder(false);
+            zipFile.addFolder(entity.getPath().toFile(), parameters);
         } else {
-            ZipUtil.addFileToZipStream(
-                    zipStream,
-                    entity.getPath().toFile(),
-                    prefix + entity.getId());
+            ZipParameters zipParameters = new ZipParameters();
+            zipParameters.setFileNameInZip(prefix + entity.getId());
+            zipFile.addFile(entity.getPath().toFile(), zipParameters);
         }
     }
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/WriteZipStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/WriteZipStrategy.java
@@ -1,27 +1,13 @@
 package edu.kit.datamanager.ro_crate.writer;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.kit.datamanager.ro_crate.Crate;
-import edu.kit.datamanager.ro_crate.entities.data.DataEntity;
-import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
-import edu.kit.datamanager.ro_crate.preview.CratePreview;
-import edu.kit.datamanager.ro_crate.util.FileSystemUtil;
-import net.lingala.zip4j.ZipFile;
-import net.lingala.zip4j.model.ZipParameters;
-import org.apache.commons.io.FileUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.io.OutputStream;
 
 /**
  * Implementation of the writing strategy to provide a way of writing crates to
@@ -32,108 +18,16 @@ public class WriteZipStrategy implements
         ElnFormatWriter<String>
 {
     private static final Logger logger = LoggerFactory.getLogger(WriteZipStrategy.class);
-    public static final String TMP_DIR = "./.tmp/ro-crate-java/writer-zip-strategy/";
-
-    /**
-     * Defines if the zip file will directly contain the crate,
-     * or if it will contain a subdirectory with the crate.
-     */
-    protected boolean createRootSubdir = false;
+    protected ElnFormatWriter<OutputStream> delegate = new WriteZipStreamStrategy();
 
     @Override
     public ElnFormatWriter<String> usingElnStyle() {
-        this.createRootSubdir = true;
+        this.delegate = this.delegate.withRootSubdirectory();
         return this;
     }
 
     @Override
     public void save(Crate crate, String destination) throws IOException {
-        String innerFolderName = "";
-        if (this.createRootSubdir) {
-            innerFolderName = FileSystemUtil.filterExtensionsFromFileName(
-                    Path.of(destination).getFileName().toString(),
-                    Set.of("ELN", "ZIP"));
-            innerFolderName = FileSystemUtil.ensureTrailingSlash(innerFolderName);
-        }
-        try (ZipFile zipFile = new ZipFile(destination)) {
-            saveMetadataJson(crate, zipFile, innerFolderName);
-            saveDataEntities(crate, zipFile, innerFolderName);
-            savePreview(crate, zipFile, innerFolderName);
-        }
-    }
-
-    private void saveDataEntities(Crate crate, ZipFile zipFile, String prefix) throws IOException {
-        for (DataEntity dataEntity : crate.getAllDataEntities()) {
-            this.saveToZip(dataEntity, zipFile, prefix);
-        }
-    }
-
-    private void saveMetadataJson(Crate crate, ZipFile zipFile, String prefix) throws IOException {
-        // write the metadata.json file
-        ZipParameters zipParameters = new ZipParameters();
-        zipParameters.setFileNameInZip(prefix + "ro-crate-metadata.json");
-        ObjectMapper objectMapper = MyObjectMapper.getMapper();
-        // we create an JsonNode only to have the file written pretty
-        JsonNode node = objectMapper.readTree(crate.getJsonMetadata());
-        String str = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(node);
-        try (InputStream inputStream = new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8))) {
-            // write the ro-crate-metadata
-            zipFile.addStream(inputStream, zipParameters);
-        }
-    }
-
-    private void savePreview(Crate crate, ZipFile zipFile, String prefix) throws IOException {
-        Optional<CratePreview> preview = Optional.ofNullable(crate.getPreview());
-        if (preview.isEmpty()) {
-            return;
-        }
-        final String ID = UUID.randomUUID().toString();
-        File tmpPreviewFolder = Path.of(TMP_DIR)
-                .resolve(ID)
-                .toFile();
-        FileUtils.forceMkdir(tmpPreviewFolder);
-        FileUtils.forceDeleteOnExit(tmpPreviewFolder);
-
-        preview.get().generate(crate, tmpPreviewFolder);
-        String[] paths = tmpPreviewFolder.list();
-        if (paths == null) {
-            throw new IOException("No preview files found in temporary folder. Preview generation failed.");
-        }
-        for (String path : paths) {
-            File file = tmpPreviewFolder.toPath().resolve(path).toFile();
-            if (file.isDirectory()) {
-                ZipParameters parameters = new ZipParameters();
-                parameters.setRootFolderNameInZip(prefix + path);
-                parameters.setIncludeRootFolder(false);
-                zipFile.addFolder(file, parameters);
-            } else {
-                ZipParameters zipParameters = new ZipParameters();
-                zipParameters.setFileNameInZip(prefix + path);
-                zipFile.addFile(file, zipParameters);
-            }
-        }
-        try {
-            FileUtils.forceDelete(tmpPreviewFolder);
-        } catch (IOException e) {
-            logger.error("Could not delete temporary preview folder: {}", tmpPreviewFolder);
-        }
-    }
-
-    private void saveToZip(DataEntity entity, ZipFile zipFile, String prefix) throws IOException {
-        if (entity == null || entity.getPath() == null) {
-            return;
-        }
-
-        boolean isDirectory = entity.getPath().toFile().isDirectory();
-        if (isDirectory) {
-            ZipParameters parameters = new ZipParameters();
-            parameters.setRootFolderNameInZip(prefix + entity.getId());
-            parameters.setIncludeRootFolder(false);
-            zipFile.addFolder(entity.getPath().toFile(), parameters);
-        } else {
-            ZipParameters zipParameters = new ZipParameters();
-            zipParameters.setFileNameInZip(prefix + entity.getId());
-            zipFile.addFile(entity.getPath().toFile(), zipParameters);
-        }
+        this.delegate.save(crate, new FileOutputStream(destination));
     }
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/WriteZipStreamStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/WriteZipStreamStrategy.java
@@ -37,6 +37,11 @@ public class WriteZipStreamStrategy implements
      * or if it will contain a subdirectory with the crate.
      */
     protected boolean createRootSubdir = false;
+
+    /**
+     * In streams, we do not have a file name yet (or do not know it),
+     * so we need to set a default name for the root subdirectory.
+     */
     protected String rootSubdirName = "content";
 
     @Override

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/Writers.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/Writers.java
@@ -19,7 +19,7 @@ public class Writers {
      * @return a new instance of {@link CrateWriter} for writing to a folder
      */
     public static CrateWriter<String> newFolderWriter() {
-        return new CrateWriter<>(new FolderStrategy());
+        return new CrateWriter<>(new WriteFolderStrategy());
     }
 
     /**
@@ -28,7 +28,7 @@ public class Writers {
      * @return a new instance of {@link CrateWriter} for writing to a zip stream
      */
     public static CrateWriter<OutputStream> newZipStreamWriter() {
-        return new CrateWriter<>(new ZipStreamStrategy());
+        return new CrateWriter<>(new WriteZipStreamStrategy());
     }
 
     /**
@@ -37,6 +37,6 @@ public class Writers {
      * @return a new instance of {@link CrateWriter} for writing to a zip file
      */
     public static CrateWriter<String> newZipPathWriter() {
-        return new CrateWriter<>(new ZipStrategy());
+        return new CrateWriter<>(new WriteZipStrategy());
     }
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/ZipStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/ZipStrategy.java
@@ -5,42 +5,78 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.kit.datamanager.ro_crate.Crate;
 import edu.kit.datamanager.ro_crate.entities.data.DataEntity;
 import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
+import edu.kit.datamanager.ro_crate.preview.CratePreview;
 import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.model.ZipParameters;
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.regex.Matcher;
 
 /**
  * Implementation of the writing strategy to provide a way of writing crates to
  * a zip archive.
  */
-public class ZipStrategy implements GenericWriterStrategy<String> {
-
+public class ZipStrategy implements
+        GenericWriterStrategy<String>,
+        ElnFormatWriter<String>
+{
     private static final Logger logger = LoggerFactory.getLogger(ZipStrategy.class);
+
+    /**
+     * Defines if the zip file will directly contain the crate,
+     * or if it will contain a subdirectory with the crate.
+     */
+    protected boolean createRootSubdir = false;
+
+    @Override
+    public ElnFormatWriter<String> usingElnStyle() {
+        this.createRootSubdir = true;
+        return this;
+    }
 
     @Override
     public void save(Crate crate, String destination) throws IOException {
+        String innerFolderName = "";
+        if (this.createRootSubdir) {
+            String dot = Matcher.quoteReplacement(".");
+            String end = Matcher.quoteReplacement("$");
+            innerFolderName = Path.of(destination).getFileName()
+                    .toString()
+                    // remove .zip or .eln from the end of the file name
+                    // (?i) removes case sensitivity
+                    .replaceFirst("(?i)" + dot + "zip" + end, "")
+                    .replaceFirst("(?i)" + dot + "eln" + end, "");
+            if (!innerFolderName.endsWith("/")) {
+                innerFolderName += "/";
+            }
+        }
         try (ZipFile zipFile = new ZipFile(destination)) {
-            saveMetadataJson(crate, zipFile);
-            saveDataEntities(crate, zipFile);
+            saveMetadataJson(crate, zipFile, innerFolderName);
+            saveDataEntities(crate, zipFile, innerFolderName);
+            savePreview(crate, zipFile, innerFolderName);
         }
     }
 
-    private void saveDataEntities(Crate crate, ZipFile zipFile) throws IOException {
+    private void saveDataEntities(Crate crate, ZipFile zipFile, String prefix) throws IOException {
         for (DataEntity dataEntity : crate.getAllDataEntities()) {
-            this.saveToZip(dataEntity, zipFile);
+            this.saveToZip(dataEntity, zipFile, prefix);
         }
     }
 
-    private void saveMetadataJson(Crate crate, ZipFile zipFile) throws IOException {
+    private void saveMetadataJson(Crate crate, ZipFile zipFile, String prefix) throws IOException {
         // write the metadata.json file
         ZipParameters zipParameters = new ZipParameters();
-        zipParameters.setFileNameInZip("ro-crate-metadata.json");
+        zipParameters.setFileNameInZip(prefix + "ro-crate-metadata.json");
         ObjectMapper objectMapper = MyObjectMapper.getMapper();
         // we create an JsonNode only to have the file written pretty
         JsonNode node = objectMapper.readTree(crate.getJsonMetadata());
@@ -49,12 +85,46 @@ public class ZipStrategy implements GenericWriterStrategy<String> {
             // write the ro-crate-metadata
             zipFile.addStream(inputStream, zipParameters);
         }
-        if (crate.getPreview() != null) {
-            crate.getPreview().saveAllToZip(zipFile);
+    }
+
+    private void savePreview(Crate crate, ZipFile zipFile, String prefix) throws IOException {
+        Optional<CratePreview> preview = Optional.ofNullable(crate.getPreview());
+        if (preview.isEmpty()) {
+            return;
+        }
+        final String ID = UUID.randomUUID().toString();
+        File tmpPreviewFolder = Path.of("./.tmp/ro-crate-java/writer-zipStrategy/")
+                .resolve(ID)
+                .toFile();
+        FileUtils.forceMkdir(tmpPreviewFolder);
+        FileUtils.forceDeleteOnExit(tmpPreviewFolder);
+
+        preview.get().generate(crate, tmpPreviewFolder);
+        String[] paths = tmpPreviewFolder.list();
+        if (paths == null) {
+            throw new IOException("No files found in temporary folder");
+        }
+        for (String path : paths) {
+            File file = tmpPreviewFolder.toPath().resolve(path).toFile();
+            if (file.isDirectory()) {
+                ZipParameters parameters = new ZipParameters();
+                parameters.setRootFolderNameInZip(prefix + path);
+                parameters.setIncludeRootFolder(false);
+                zipFile.addFolder(file, parameters);
+            } else {
+                ZipParameters zipParameters = new ZipParameters();
+                zipParameters.setFileNameInZip(prefix + path);
+                zipFile.addFile(file, zipParameters);
+            }
+        }
+        try {
+            FileUtils.forceDelete(tmpPreviewFolder);
+        } catch (IOException e) {
+            logger.error("Could not delete temporary preview folder: {}", tmpPreviewFolder);
         }
     }
 
-    private void saveToZip(DataEntity entity, ZipFile zipFile) throws IOException {
+    private void saveToZip(DataEntity entity, ZipFile zipFile, String prefix) throws IOException {
         if (entity == null || entity.getPath() == null) {
             return;
         }
@@ -62,12 +132,12 @@ public class ZipStrategy implements GenericWriterStrategy<String> {
         boolean isDirectory = entity.getPath().toFile().isDirectory();
         if (isDirectory) {
             ZipParameters parameters = new ZipParameters();
-            parameters.setRootFolderNameInZip(entity.getId());
+            parameters.setRootFolderNameInZip(prefix + entity.getId());
             parameters.setIncludeRootFolder(false);
             zipFile.addFolder(entity.getPath().toFile(), parameters);
         } else {
             ZipParameters zipParameters = new ZipParameters();
-            zipParameters.setFileNameInZip(entity.getId());
+            zipParameters.setFileNameInZip(prefix + entity.getId());
             zipFile.addFile(entity.getPath().toFile(), zipParameters);
         }
     }

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/ZipStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/ZipStrategy.java
@@ -6,7 +6,6 @@ import edu.kit.datamanager.ro_crate.Crate;
 import edu.kit.datamanager.ro_crate.entities.data.DataEntity;
 import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
 import net.lingala.zip4j.ZipFile;
-import net.lingala.zip4j.exception.ZipException;
 import net.lingala.zip4j.model.ZipParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,9 +31,9 @@ public class ZipStrategy implements GenericWriterStrategy<String> {
         }
     }
 
-    private void saveDataEntities(Crate crate, ZipFile zipFile) throws ZipException {
+    private void saveDataEntities(Crate crate, ZipFile zipFile) throws IOException {
         for (DataEntity dataEntity : crate.getAllDataEntities()) {
-            dataEntity.saveToZip(zipFile);
+            this.saveToZip(dataEntity, zipFile);
         }
     }
 
@@ -52,6 +51,24 @@ public class ZipStrategy implements GenericWriterStrategy<String> {
         }
         if (crate.getPreview() != null) {
             crate.getPreview().saveAllToZip(zipFile);
+        }
+    }
+
+    private void saveToZip(DataEntity entity, ZipFile zipFile) throws IOException {
+        if (entity == null || entity.getPath() == null) {
+            return;
+        }
+
+        boolean isDirectory = entity.getPath().toFile().isDirectory();
+        if (isDirectory) {
+            ZipParameters parameters = new ZipParameters();
+            parameters.setRootFolderNameInZip(entity.getId());
+            parameters.setIncludeRootFolder(false);
+            zipFile.addFolder(entity.getPath().toFile(), parameters);
+        } else {
+            ZipParameters zipParameters = new ZipParameters();
+            zipParameters.setFileNameInZip(entity.getId());
+            zipFile.addFile(entity.getPath().toFile(), zipParameters);
         }
     }
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/ZipStreamStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/ZipStreamStrategy.java
@@ -7,16 +7,18 @@ import edu.kit.datamanager.ro_crate.Crate;
 import edu.kit.datamanager.ro_crate.entities.data.DataEntity;
 import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.regex.Matcher;
 
+import edu.kit.datamanager.ro_crate.preview.CratePreview;
 import edu.kit.datamanager.ro_crate.util.ZipUtil;
-import net.lingala.zip4j.exception.ZipException;
 import net.lingala.zip4j.io.outputstream.ZipOutputStream;
 import net.lingala.zip4j.model.ZipParameters;
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,28 +26,72 @@ import org.slf4j.LoggerFactory;
  * Implementation of the writing strategy to provide a way of writing crates to
  * a zip archive.
  */
-public class ZipStreamStrategy implements GenericWriterStrategy<OutputStream> {
+public class ZipStreamStrategy implements
+        GenericWriterStrategy<OutputStream>,
+        ElnFormatWriter<OutputStream> {
 
     private static final Logger logger = LoggerFactory.getLogger(ZipStreamStrategy.class);
 
+    /**
+     * Defines if the zip file will directly contain the crate,
+     * or if it will contain a subdirectory with the crate.
+     */
+    protected boolean createRootSubdir = false;
+    protected String rootSubdirName = "content";
+
+    @Override
+    public ElnFormatWriter<OutputStream> usingElnStyle() {
+        this.createRootSubdir = true;
+        return this;
+    }
+
+    /**
+     * Sets the name of a root subdirectory in the zip file.
+     * Implicitly also enables the creation of a root subdirectory.
+     * If used for ELN files, note the subdirectory name should be the same as the zip
+     * files name.
+     *
+     * @param name the name of the subdirectory
+     * @return this instance of ZipStreamStrategy
+     */
+    public ZipStreamStrategy setSubdirectoryName(String name) {
+        this.rootSubdirName = name;
+        this.createRootSubdir = true;
+        return this;
+    }
+
     @Override
     public void save(Crate crate, OutputStream destination) throws IOException {
+        String innerFolderName = "";
+        if (this.createRootSubdir) {
+            String dot = Matcher.quoteReplacement(".");
+            String end = Matcher.quoteReplacement("$");
+            innerFolderName = this.rootSubdirName
+                    // remove .zip or .eln from the end of the file name
+                    // (?i) removes case sensitivity
+                    .replaceFirst("(?i)" + dot + "zip" + end, "")
+                    .replaceFirst("(?i)" + dot + "eln" + end, "");
+            if (!innerFolderName.endsWith("/")) {
+                innerFolderName += "/";
+            }
+        }
         try (ZipOutputStream zipFile = new ZipOutputStream(destination)) {
-            saveMetadataJson(crate, zipFile);
-            saveDataEntities(crate, zipFile);
+            saveMetadataJson(crate, zipFile, innerFolderName);
+            saveDataEntities(crate, zipFile, innerFolderName);
+            savePreview(crate, zipFile, innerFolderName);
         }
     }
 
-    private void saveDataEntities(Crate crate, ZipOutputStream zipStream) throws IOException {
+    private void saveDataEntities(Crate crate, ZipOutputStream zipStream, String prefix) throws IOException {
         for (DataEntity dataEntity : crate.getAllDataEntities()) {
-            saveToStream(dataEntity, zipStream);
+            this.saveToStream(dataEntity, zipStream, prefix);
         }
     }
 
-    private void saveMetadataJson(Crate crate, ZipOutputStream zipStream) throws IOException {
+    private void saveMetadataJson(Crate crate, ZipOutputStream zipStream, String prefix) throws IOException {
         // write the metadata.json file
         ZipParameters zipParameters = new ZipParameters();
-        zipParameters.setFileNameInZip("ro-crate-metadata.json");
+        zipParameters.setFileNameInZip(prefix + "ro-crate-metadata.json");
         ObjectMapper objectMapper = MyObjectMapper.getMapper();
         // we create an JsonNode only to have the file written pretty
         JsonNode node = objectMapper.readTree(crate.getJsonMetadata());
@@ -61,13 +107,47 @@ public class ZipStreamStrategy implements GenericWriterStrategy<OutputStream> {
             }
         }
         zipStream.closeEntry();
+    }
 
-        if (crate.getPreview() != null) {
-            crate.getPreview().saveAllToStream(str, zipStream);
+    private void savePreview(Crate crate, ZipOutputStream zipStream, String prefix) throws IOException {
+        Optional<CratePreview> preview = Optional.ofNullable(crate.getPreview());
+        if (preview.isEmpty()) {
+            return;
+        }
+        final String ID = UUID.randomUUID().toString();
+        File tmpPreviewFolder = Path.of("./.tmp/ro-crate-java/writer-zipStrategy/")
+                .resolve(ID)
+                .toFile();
+        FileUtils.forceMkdir(tmpPreviewFolder);
+        FileUtils.forceDeleteOnExit(tmpPreviewFolder);
+
+        preview.get().generate(crate, tmpPreviewFolder);
+        String[] paths = tmpPreviewFolder.list();
+        if (paths == null) {
+            throw new IOException("No files found in temporary folder");
+        }
+        for (String path : paths) {
+            File file = tmpPreviewFolder.toPath().resolve(path).toFile();
+            if (file.isDirectory()) {
+                ZipUtil.addFolderToZipStream(
+                        zipStream,
+                        file,
+                        prefix + path);
+            } else {
+                ZipUtil.addFileToZipStream(
+                        zipStream,
+                        file,
+                        prefix + path);
+            }
+        }
+        try {
+            FileUtils.forceDelete(tmpPreviewFolder);
+        } catch (IOException e) {
+            logger.error("Could not delete temporary preview folder: {}", tmpPreviewFolder);
         }
     }
 
-    private void saveToStream(DataEntity entity, ZipOutputStream zipStream) throws IOException {
+    private void saveToStream(DataEntity entity, ZipOutputStream zipStream, String prefix) throws IOException {
         if (entity == null) {
             return;
         }
@@ -77,12 +157,12 @@ public class ZipStreamStrategy implements GenericWriterStrategy<OutputStream> {
             ZipUtil.addFolderToZipStream(
                     zipStream,
                     entity.getPath().toAbsolutePath().toString(),
-                    entity.getId());
+                    prefix + entity.getId());
         } else {
             ZipUtil.addFileToZipStream(
                     zipStream,
                     entity.getPath().toFile(),
-                    entity.getId());
+                    prefix + entity.getId());
         }
     }
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/ZipStreamStrategy.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/ZipStreamStrategy.java
@@ -67,15 +67,6 @@ public class ZipStreamStrategy implements GenericWriterStrategy<OutputStream> {
         }
     }
 
-    /**
-     * If the data entity contains a physical file. This method will write it
-     * when the crate is being written to a zip archive.
-     *
-     * @param zipStream The zip output stream where it should be written.
-     * @throws ZipException when something goes wrong with the writing to the
-     * zip file.
-     * @throws IOException If opening the file input stream fails.
-     */
     private void saveToStream(DataEntity entity, ZipOutputStream zipStream) throws IOException {
         if (entity == null) {
             return;

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/ZipWriter.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/ZipWriter.java
@@ -4,7 +4,7 @@ package edu.kit.datamanager.ro_crate.writer;
  * Implementation of the writing strategy to provide a way of writing crates to
  * a zip archive.
  *
- * @deprecated Use {@link ZipStrategy} instead.
+ * @deprecated Use {@link WriteZipStrategy} instead.
  */
 @Deprecated(since = "2.1.0", forRemoval = true)
-public class ZipWriter extends ZipStrategy {}
+public class ZipWriter extends WriteZipStrategy {}

--- a/src/test/java/edu/kit/datamanager/ro_crate/HelpFunctions.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/HelpFunctions.java
@@ -17,6 +17,8 @@ import org.opentest4j.AssertionFailedError;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -151,5 +153,26 @@ public class HelpFunctions {
             }
         }
         return true;
+    }
+
+    /**
+     * Prints the file tree of the given directory for debugging and understanding
+     * a test more quickly.
+     *
+     * @param directoryToPrint the directory to print
+     * @throws IOException if an error occurs while printing the file tree
+     */
+    @SuppressWarnings("resource")
+    public static void printFileTree(Path directoryToPrint) throws IOException {
+        // Print all files recursively in a tree structure for debugging
+        System.out.printf("Files in %s:%n", directoryToPrint.getFileName().toString());
+        Files.walk(directoryToPrint)
+                .forEach(path -> {
+                    if (!path.toAbsolutePath().equals(directoryToPrint.toAbsolutePath())) {
+                        int depth = path.relativize(directoryToPrint).getNameCount();
+                        String prefix = "  ".repeat(depth);
+                        System.out.printf("%s%s%s%n", prefix, "└── ", path.getFileName());
+                    }
+                });
     }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/BuilderSpec12Test.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/BuilderSpec12Test.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
@@ -37,7 +38,7 @@ class BuilderSpec12Test {
     }
 
     @Test
-    void testModificationOfDraftCrate() throws URISyntaxException {
+    void testModificationOfDraftCrate() throws URISyntaxException, IOException {
         String path = this.getClass().getResource("/crates/spec-1.2-DRAFT/minimal-with-conformsTo-Array").getPath();
         RoCrate crate = Readers.newFolderReader().readCrate(path);
         Collection<String> existingProfiles = crate.getProfiles();

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/ReadAndWriteTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/ReadAndWriteTest.java
@@ -49,7 +49,7 @@ class ReadAndWriteTest {
 
   @SuppressWarnings("DataFlowIssue")
   @Test
-  void testReadCrateWithHasPartHierarchy() {
+  void testReadCrateWithHasPartHierarchy() throws IOException {
     CrateReader<String> reader = Readers.newFolderReader();
     RoCrate crate = reader.readCrate(ReadAndWriteTest.class.getResource("/crates/hasPartHierarchy").getPath());
     assertEquals(1, crate.getAllContextualEntities().size());

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/TestRemoveAddContext.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/TestRemoveAddContext.java
@@ -6,6 +6,7 @@ import edu.kit.datamanager.ro_crate.RoCrate;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
+import java.io.IOException;
 import java.util.Objects;
 import java.util.Set;
 
@@ -17,7 +18,7 @@ public class TestRemoveAddContext {
   private RoCrate crateWithComplexContext;
 
   @BeforeEach
-  void setup() {
+  void setup() throws IOException {
     String crateManifestPath = "/crates/extendedContextExample/";
     crateManifestPath = Objects.requireNonNull(TestRemoveAddContext.class.getResource(crateManifestPath)).getPath();
     this.crateWithComplexContext = Readers.newFolderReader().readCrate(crateManifestPath);

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/preview/PreviewCrateTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/preview/PreviewCrateTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class PreviewCrateTest {
 
     @Test
-    void testAutomaticPreview(@TempDir Path temp) {
+    void testAutomaticPreview(@TempDir Path temp) throws IOException {
         Path location = temp.resolve("ro_crate1");
         RoCrate crate = new RoCrate.RoCrateBuilder("name", "description", "2024", "https://creativecommons.org/licenses/by-nc-sa/3.0/au/")
                 .setPreview(new AutomaticPreview())
@@ -33,7 +33,7 @@ public class PreviewCrateTest {
     }
 
     @Test
-    void testAutomaticPreviewAddingLater(@TempDir Path temp) {
+    void testAutomaticPreviewAddingLater(@TempDir Path temp) throws IOException {
         Path location = temp.resolve("ro_crate2");
         RoCrate crate = new RoCrate.RoCrateBuilder("name", "description", "2024", "https://creativecommons.org/licenses/by-nc-sa/3.0/au/")
                 .setPreview(null)//disable preview to allow to compare folders before and after
@@ -47,7 +47,7 @@ public class PreviewCrateTest {
     }
 
     @Test
-    void testCustomPreview(@TempDir Path temp) {
+    void testCustomPreview(@TempDir Path temp) throws IOException {
         Path location = temp.resolve("ro_crate1");
         RoCrate crate = new RoCrate.RoCrateBuilder("name", "description", "2024", "https://creativecommons.org/licenses/by-nc-sa/3.0/au/")
                 .setPreview(new CustomPreview())

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/realexamples/RealTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/realexamples/RealTest.java
@@ -12,7 +12,6 @@ import edu.kit.datamanager.ro_crate.entities.contextual.PlaceEntity;
 import edu.kit.datamanager.ro_crate.entities.data.DataSetEntity;
 import edu.kit.datamanager.ro_crate.entities.data.FileEntity;
 import edu.kit.datamanager.ro_crate.externalproviders.personprovider.OrcidProvider;
-import edu.kit.datamanager.ro_crate.reader.CrateReader;
 import edu.kit.datamanager.ro_crate.reader.Readers;
 
 import org.apache.commons.io.FileUtils;
@@ -23,17 +22,17 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-class RealTest {
-
-    @SuppressWarnings("java:S2699") // disable warning about missing assertions
+class RealTest
+{
     @Test
     void testWithIDRCProject(@TempDir Path temp) throws IOException {
-
-        CrateReader<String> reader = Readers.newFolderReader();
         final String locationMetadataFile = "/crates/other/idrc_project/ro-crate-metadata.json";
-        Crate crate = reader.readCrate(RealTest.class.getResource("/crates/other/idrc_project").getPath());
+        Crate crate = Readers.newFolderReader()
+                .readCrate(RealTest.class.getResource("/crates/other/idrc_project").getPath());
 
+        assertNotNull(crate);
         HelpFunctions.compareCrateJsonToFileInResources(crate, locationMetadataFile);
 
         Path newFile = temp.resolve("new_file.txt");
@@ -47,6 +46,7 @@ class RealTest {
                         .build());
 
         PersonEntity person = OrcidProvider.getPerson("https://orcid.org/0000-0001-9842-9718");
+        assertNotNull(person);
         crate.addContextualEntity(person);
 
         // problem

--- a/src/test/java/edu/kit/datamanager/ro_crate/entities/contextual/ContextualEntityTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/entities/contextual/ContextualEntityTest.java
@@ -1,12 +1,15 @@
 package edu.kit.datamanager.ro_crate.entities.contextual;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.IOException;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import edu.kit.datamanager.ro_crate.HelpFunctions;
 
+import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Nikola Tzotchev on 5.2.2022 г.
@@ -44,5 +47,103 @@ public class ContextualEntityTest {
 
     assertTrue(place.getLinkedTo().contains(geo.getId()));
     HelpFunctions.compareEntityWithFile(place, "/json/entities/contextual/place.json");
+  }
+
+  @Test
+  void testAddAllValidCase() throws JsonProcessingException {
+    ContextualEntity first = new ContextualEntity.ContextualEntityBuilder()
+        .setId("#b4168a98-8534-4c6d-a568-64a55157b656")
+        .addType("GeoCoordinates")
+        .addProperty("latitude", "-33.7152")
+        .addProperty("longitude", "150.30119")
+        .addProperty("name", "Latitude: -33.7152 Longitude: 150.30119")
+        .build();
+
+    String allProperties = """
+            {
+                "@id": "#b4168a98-8534-4c6d-a568-64a55157b656",
+                "@type": "GeoCoordinates",
+                "latitude": "-33.7152",
+                "longitude": "150.30119",
+                "name": "Latitude: -33.7152 Longitude: 150.30119"
+            }
+            """;
+
+    ObjectNode properties = MyObjectMapper.getMapper()
+            .readValue(allProperties, ObjectNode.class);
+    ContextualEntity second = new ContextualEntity.ContextualEntityBuilder()
+            .setAllIfValid(properties)
+            .build();
+    assertEquals(second.getProperties(), first.getProperties());
+  }
+
+  @Test
+  void testAddAllInvalidCase() throws JsonProcessingException {
+    ContextualEntity first = new ContextualEntity.ContextualEntityBuilder()
+            .setId("#b4168a98-8534-4c6d-a568-64a55157b656")
+            .addType("GeoCoordinates")
+            .addProperty("latitude", "-33.7152")
+            .addProperty("longitude", "150.30119")
+            .addProperty("name", "Latitude: -33.7152 Longitude: 150.30119")
+            .build();
+
+    String allProperties = """
+            {
+                "wrong property": {"any": "value"},
+                "@id": "#b4168a98-8534-4c6d-a568-64a55157b656",
+                "@type": "GeoCoordinates",
+                "latitude": "-33.7152",
+                "longitude": "150.30119",
+                "name": "Latitude: -33.7152 Longitude: 150.30119"
+            }
+            """;
+
+    ObjectNode properties = MyObjectMapper.getMapper()
+            .readValue(allProperties, ObjectNode.class);
+    ContextualEntity second = new ContextualEntity.ContextualEntityBuilder()
+            .setId("second")
+            .setAllIfValid(properties)
+            .build();
+    assertNotEquals(second.getProperties(), first.getProperties());
+    ObjectNode empty = new ContextualEntity.ContextualEntityBuilder()
+            .setId("second")
+            .build()
+            .getProperties();
+    assertEquals(empty, second.getProperties());
+  }
+
+  @Test
+  void testAddAllUnsafeDoesInvalidCase() throws JsonProcessingException {
+    ContextualEntity first = new ContextualEntity.ContextualEntityBuilder()
+            .setId("#b4168a98-8534-4c6d-a568-64a55157b656")
+            .addType("GeoCoordinates")
+            .addProperty("latitude", "-33.7152")
+            .addProperty("longitude", "150.30119")
+            .addProperty("name", "Latitude: -33.7152 Longitude: 150.30119")
+            .build();
+
+    String allProperties = """
+            {
+                "wrong property": {"any": "value"},
+                "@id": "#b4168a98-8534-4c6d-a568-64a55157b656",
+                "@type": "GeoCoordinates",
+                "latitude": "-33.7152",
+                "longitude": "150.30119",
+                "name": "Latitude: -33.7152 Longitude: 150.30119"
+            }
+            """;
+
+    ObjectNode properties = MyObjectMapper.getMapper()
+            .readValue(allProperties, ObjectNode.class);
+    ContextualEntity second = new ContextualEntity.ContextualEntityBuilder()
+            .setId("second")
+            .setAllUnsafe(properties)
+            .build();
+    assertNotEquals(second.getProperties(), first.getProperties());
+    ObjectNode empty = new ContextualEntity.ContextualEntityBuilder()
+            .setId("second")
+            .build()
+            .getProperties();
+    assertNotEquals(empty, second.getProperties());
   }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/examples/LearnByExampleTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/examples/LearnByExampleTest.java
@@ -17,7 +17,7 @@ import edu.kit.datamanager.ro_crate.reader.Readers;
 import edu.kit.datamanager.ro_crate.validation.JsonSchemaValidation;
 import edu.kit.datamanager.ro_crate.validation.Validator;
 import edu.kit.datamanager.ro_crate.writer.CrateWriter;
-import edu.kit.datamanager.ro_crate.writer.FolderStrategy;
+import edu.kit.datamanager.ro_crate.writer.WriteFolderStrategy;
 import edu.kit.datamanager.ro_crate.writer.GenericWriterStrategy;
 import edu.kit.datamanager.ro_crate.writer.Writers;
 import org.apache.commons.io.FileUtils;
@@ -336,13 +336,13 @@ public class LearnByExampleTest {
 
         // Now, let's write it to a folder. Note the used strategy could be replaced with your own.
         Path folder = tempDir.resolve("folderCrate");
-        new CrateWriter<>(new FolderStrategy())
+        new CrateWriter<>(new WriteFolderStrategy())
                 .save(crate, folder.toString());
         // and read it back.
         RoCrate read = new CrateReader<>(
-                // Note: There are two FolderStrategy implementations, one for reading and one for writing.
+                // Note: There are two WriteFolderStrategy implementations, one for reading and one for writing.
                 // Java is a bit bad with imports, so we use the fully qualified name here.
-                new edu.kit.datamanager.ro_crate.reader.FolderStrategy()
+                new edu.kit.datamanager.ro_crate.reader.ReadFolderStrategy()
         )
                 .readCrate(folder.toAbsolutePath().toString());
 

--- a/src/test/java/edu/kit/datamanager/ro_crate/examples/LearnByExampleTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/examples/LearnByExampleTest.java
@@ -42,20 +42,22 @@ public class LearnByExampleTest {
     /**
      * This creates a valid, empty RO-Crate builder.
      */
-    static final RoCrate.RoCrateBuilder STARTER_CRATE = new RoCrate.RoCrateBuilder(
-            "name",
-            "description",
-            "2025",
-            "licenseIdentifier"
-    );
+    static RoCrate.RoCrateBuilder NEW_STARTER_CRATE() {
+        return new RoCrate.RoCrateBuilder(
+                "name",
+                "description",
+                "2025",
+                "licenseIdentifier"
+        );
+    }
 
     /**
      * Calling the `build()` method on the builder creates a valid RO-Crate.
-     * Run this test to view the STARTER_CRATE JSON in the console.
+     * Run this test to view the NEW_STARTER_CRATE() JSON in the console.
      */
     @Test
     void aSimpleCrate() {
-        RoCrate almostEmptyCrate = STARTER_CRATE.build();
+        RoCrate almostEmptyCrate = NEW_STARTER_CRATE().build();
         assertNotNull(almostEmptyCrate);
         HelpFunctions.prettyPrintJsonString(almostEmptyCrate.getJsonMetadata());
     }
@@ -72,7 +74,7 @@ public class LearnByExampleTest {
      */
     @Test
     void addingYourFirstEntity() {
-        RoCrate myFirstCrate = STARTER_CRATE
+        RoCrate myFirstCrate = NEW_STARTER_CRATE()
                 // We can add new terms to our crate. The terms we can use are called "context".
                 .addValuePairToContext("Station", "www.station.com")
                 // We can also add whole contexts to our crate.
@@ -115,7 +117,7 @@ public class LearnByExampleTest {
      */
     @Test
     void specializingYourFirstEntity() {
-        RoCrate crate = STARTER_CRATE
+        RoCrate crate = NEW_STARTER_CRATE()
                 .addDataEntity(
                         // Let's do something custom:
                         new DataEntity.DataEntityBuilder()
@@ -148,7 +150,7 @@ public class LearnByExampleTest {
         // Let's say this is the file we would like to point at with an entity.
         String lovelyFile = "https://github.com/kit-data-manager/ro-crate-java/issues/5";
 
-        RoCrate crate = STARTER_CRATE
+        RoCrate crate = NEW_STARTER_CRATE()
                 .addDataEntity(
                         // Build our entity to point to the file:
                         new FileEntity.FileEntityBuilder()
@@ -187,7 +189,7 @@ public class LearnByExampleTest {
         // But in the crate we want it to be
         String seriousExperimentFile = "fantastic-experiment/2025-01-01.csv";
 
-        RoCrate crate = STARTER_CRATE
+        RoCrate crate = NEW_STARTER_CRATE()
                 .addDataEntity(
                         // Build our entity to point to the file:
                         new FileEntity.FileEntityBuilder()
@@ -236,7 +238,7 @@ public class LearnByExampleTest {
         PersonEntity person = OrcidProvider.getPerson("https://orcid.org/0000-0001-6575-1022");
         OrganizationEntity organization = RorProvider.getOrganization("https://ror.org/04t3en479");
 
-        RoCrate crate = STARTER_CRATE
+        RoCrate crate = NEW_STARTER_CRATE()
                 .addContextualEntity(person)
                 .addContextualEntity(organization)
                 .build();
@@ -263,7 +265,7 @@ public class LearnByExampleTest {
         PersonEntity person = OrcidProvider.getPerson("https://orcid.org/0000-0001-6575-1022");
         OrganizationEntity organization = RorProvider.getOrganization("https://ror.org/04t3en479");
 
-        RoCrate crate = STARTER_CRATE
+        RoCrate crate = NEW_STARTER_CRATE()
                 .addContextualEntity(person)
                 .addContextualEntity(organization)
                 .build();
@@ -324,7 +326,7 @@ public class LearnByExampleTest {
         PersonEntity person = OrcidProvider.getPerson("https://orcid.org/0000-0001-6575-1022");
         OrganizationEntity organization = RorProvider.getOrganization("https://ror.org/04t3en479");
 
-        RoCrate crate = STARTER_CRATE
+        RoCrate crate = NEW_STARTER_CRATE()
                 .addContextualEntity(person)
                 .addContextualEntity(organization)
                 .build();
@@ -368,7 +370,7 @@ public class LearnByExampleTest {
      */
     @Test
     void humanReadableContent() {
-        RoCrate crate = STARTER_CRATE
+        RoCrate crate = NEW_STARTER_CRATE()
                 .setPreview(new AutomaticPreview())
                 .build();
 
@@ -380,11 +382,13 @@ public class LearnByExampleTest {
      * Therefore, the constructor is a bit more complicated.
      */
     @Test
-    void staticPreview(@TempDir Path tempDir) {
+    void staticPreview(@TempDir Path tempDir) throws IOException {
         File mainPreviewHtml = tempDir.resolve("mainPreview.html").toFile();
         File additionalFilesDirectory = tempDir.resolve("additionalFiles").toFile();
+        FileUtils.forceMkdir(additionalFilesDirectory);
+        FileUtils.touch(mainPreviewHtml);
 
-        RoCrate crate = STARTER_CRATE
+        RoCrate crate = NEW_STARTER_CRATE()
                 .setPreview(new StaticPreview(mainPreviewHtml, additionalFilesDirectory))
                 .build();
 
@@ -408,7 +412,7 @@ public class LearnByExampleTest {
         String schemaPath = schemaUrl.getPath();
 
         // This crate for sure is not a workflow, so validation will fail.
-        RoCrate crate = STARTER_CRATE.build();
+        RoCrate crate = NEW_STARTER_CRATE().build();
 
         // And now do the validation.
         Validator validator = new Validator(new JsonSchemaValidation(schemaPath));

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/CommonReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/CommonReaderTest.java
@@ -27,9 +27,13 @@ import static org.junit.jupiter.api.Assertions.*;
  *           This parameter is only required to satisfy the generic reader strategy.
  * @param <READER_STRATEGY> the type of the reader strategy
  */
-abstract class CrateReaderTest<SOURCE_T, READER_STRATEGY extends GenericReaderStrategy<SOURCE_T>> {
-
-    protected static RoCrate.RoCrateBuilder newBaseCrate() {
+interface CommonReaderTest<
+        SOURCE_T,
+        READER_STRATEGY extends GenericReaderStrategy<SOURCE_T>
+        >
+        extends TestableReaderStrategy<SOURCE_T, READER_STRATEGY>
+{
+    static RoCrate.RoCrateBuilder newBaseCrate() {
         return new RoCrate.RoCrateBuilder(
                 "minimal",
                 "minimal RO_crate",
@@ -38,7 +42,7 @@ abstract class CrateReaderTest<SOURCE_T, READER_STRATEGY extends GenericReaderSt
         );
     }
 
-    protected static FileEntity newDataEntity(Path filePath) throws IllegalArgumentException {
+    static FileEntity newDataEntity(Path filePath) throws IllegalArgumentException {
         return new FileEntity.FileEntityBuilder()
                 .setLocationWithExceptions(filePath)
                 .setId(filePath.toFile().getName())
@@ -48,44 +52,8 @@ abstract class CrateReaderTest<SOURCE_T, READER_STRATEGY extends GenericReaderSt
                 .build();
     }
 
-    /**
-     * Saves the crate with the writer fitting to the reader of {@link #readCrate(Path)}.
-     *
-     * @param crate the crate to save
-     * @param target the target path to the save location
-     * @throws IOException if an error occurs while saving the crate
-     */
-    abstract protected void saveCrate(Crate crate, Path target) throws IOException;
-
-    /**
-     * Reads the crate with the reader fitting to the writer of {@link #saveCrate(Crate, Path)}.
-     * @param source the source path to the crate
-     * @return the read crate
-     * @throws IOException if an error occurs while reading the crate
-     */
-    abstract protected Crate readCrate(Path source) throws IOException;
-
-    /**
-     * Creates a new reader strategy with a non-default temporary directory (if supported, default otherwise).
-     *
-     * @param tmpDirectory the temporary directory to use
-     * @param useUuidSubfolder whether to create a UUID subfolder under the temporary directory
-     * @return a new reader strategy
-     */
-    abstract protected READER_STRATEGY newReaderStrategyWithTmp(Path tmpDirectory, boolean useUuidSubfolder);
-
-    /**
-     * Reads the crate using the provided reader strategy.
-     *
-     * @param strategy the reader strategy to use
-     * @param source the source path to the crate
-     * @return the read crate
-     * @throws IOException if an error occurs while reading the crate
-     */
-    abstract protected Crate readCrate(READER_STRATEGY strategy, Path source) throws IOException;
-
     @Test
-    void testReadingBasicCrate(@TempDir Path temp) throws IOException {
+    default void testReadingBasicCrate(@TempDir Path temp) throws IOException {
 
         RoCrate roCrate = newBaseCrate().build();
         Path zipPath = temp.resolve("result.zip");
@@ -95,7 +63,7 @@ abstract class CrateReaderTest<SOURCE_T, READER_STRATEGY extends GenericReaderSt
     }
 
     @Test
-    void testWithFile(@TempDir Path temp) throws IOException {
+    default void testWithFile(@TempDir Path temp) throws IOException {
         Path csvPath = temp.resolve("survey-responses-2019.csv");
         FileUtils.touch(csvPath.toFile());
         FileUtils.writeStringToFile(csvPath.toFile(), "Dummy content", Charset.defaultCharset());
@@ -113,7 +81,7 @@ abstract class CrateReaderTest<SOURCE_T, READER_STRATEGY extends GenericReaderSt
     }
 
     @Test
-    void testWithFileUrlEncoded(@TempDir Path temp) throws IOException {
+    default void testWithFileUrlEncoded(@TempDir Path temp) throws IOException {
         // This URL will be encoded because of whitespaces
         Path csvPath = temp.resolve("survey responses 2019.csv");
         FileUtils.touch(csvPath.toFile());
@@ -140,7 +108,7 @@ abstract class CrateReaderTest<SOURCE_T, READER_STRATEGY extends GenericReaderSt
     }
 
     @Test
-    void TestWithFileWithLocation(@TempDir Path temp) throws IOException {
+    default void TestWithFileWithLocation(@TempDir Path temp) throws IOException {
         Path csvPath = temp.resolve("survey-responses-2019.csv");
         FileUtils.writeStringToFile(csvPath.toFile(), "Dummy content", Charset.defaultCharset());
         RoCrate rawCrate = newBaseCrate()
@@ -168,7 +136,7 @@ abstract class CrateReaderTest<SOURCE_T, READER_STRATEGY extends GenericReaderSt
     }
 
     @Test
-    void TestWithFileWithLocationAddEntity(@TempDir Path temp) throws IOException {
+    default void TestWithFileWithLocationAddEntity(@TempDir Path temp) throws IOException {
         Path csvPath = temp.resolve("file.csv");
         FileUtils.writeStringToFile(csvPath.toFile(), "fakecsv.1", Charset.defaultCharset());
         RoCrate rawCrate = newBaseCrate()
@@ -206,7 +174,7 @@ abstract class CrateReaderTest<SOURCE_T, READER_STRATEGY extends GenericReaderSt
     }
 
     @Test
-    void testReadingBasicCrateWithCustomPath(@TempDir Path temp) throws IOException {
+    default void testReadingBasicCrateWithCustomPath(@TempDir Path temp) throws IOException {
         RoCrate rawCrate = newBaseCrate().build();
 
         // Write to zip file

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/CommonReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/CommonReaderTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *           This parameter is only required to satisfy the generic reader strategy.
  * @param <READER_STRATEGY> the type of the reader strategy
  */
-interface CommonReaderTest<
+public interface CommonReaderTest<
         SOURCE_T,
         READER_STRATEGY extends GenericReaderStrategy<SOURCE_T>
         >

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/ElnFileFormatTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/ElnFileFormatTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 
@@ -40,7 +41,7 @@ public interface ElnFileFormatTest<
     })
     default void testReadElnCrates(String urlStr, @TempDir Path tmp) throws IOException {
         // Download the ELN file
-        URL url = new URL(urlStr);
+        URL url = URI.create(urlStr).toURL();
         Path elnFile = tmp.resolve("downloaded.eln");
         FileUtils.copyURLToFile(url, elnFile.toFile(), 10000, 10000);
         assertTrue(elnFile.toFile().exists());

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/ElnFileFormatTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/ElnFileFormatTest.java
@@ -1,0 +1,53 @@
+package edu.kit.datamanager.ro_crate.reader;
+
+import edu.kit.datamanager.ro_crate.Crate;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public interface ElnFileFormatTest<
+        SOURCE_T,
+        READER_STRATEGY extends GenericReaderStrategy<SOURCE_T>
+        >
+        extends TestableReaderStrategy<SOURCE_T, READER_STRATEGY>
+{
+    /**
+     * ELN Crates are zip files not fully compatible with the Ro-Crate standard
+     * in the sense that they must contain a single subfolder in the zip file
+     * which then contain a crate as specified by the Ro-Crate standard.
+     * <p>
+     * Here we test if we can read them using out ZipReader.
+     *
+     * @see <a href="https://github.com/TheELNConsortium/TheELNFileFormat"></a>
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/AI4Green/Export%20workbook-2024-08-27-export.eln",
+            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/OpenSemanticLab/MinimalExample.osl.eln",
+            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/PASTA/PASTA.eln",
+            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/RSpace/RSpace-2023-12-08-14-44-xml-SELECTION-c0bEtpHcnNe-HA.eln",
+            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/SampleDB/sampledb_export.eln",
+            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/elabftw/export.eln",
+            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/kadi4mat/records-example.eln",
+            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/kadi4mat/collections-example.eln"
+    })
+    default void testReadElnCrates(String urlStr, @TempDir Path tmp) throws IOException {
+        // Download the ELN file
+        URL url = new URL(urlStr);
+        Path elnFile = tmp.resolve("downloaded.eln");
+        FileUtils.copyURLToFile(url, elnFile.toFile(), 10000, 10000);
+        assertTrue(elnFile.toFile().exists());
+
+        // Read the crate from the downloaded file
+        Crate read = this.readCrate(elnFile);
+        assertNotNull(read);
+        assertFalse(read.getAllDataEntities().isEmpty());
+    }
+}

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/FolderReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/FolderReaderTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Nikola Tzotchev on 9.2.2022 г.
  * @version 1
  */
-class FolderReaderTest implements CommonReaderTest<String, FolderStrategy>
+class FolderReaderTest implements CommonReaderTest<String, ReadFolderStrategy>
 {
   @Override
   public void saveCrate(Crate crate, Path target) throws IOException {
@@ -31,15 +31,15 @@ class FolderReaderTest implements CommonReaderTest<String, FolderStrategy>
   }
 
   @Override
-  public FolderStrategy newReaderStrategyWithTmp(Path tmpDirectory, boolean useUuidSubfolder) {
+  public ReadFolderStrategy newReaderStrategyWithTmp(Path tmpDirectory, boolean useUuidSubfolder) {
     // This strategy does not support a non-default temporary directory
     // and will always use the default one.
     // It also has no state we could make assertions on.
-    return new FolderStrategy();
+    return new ReadFolderStrategy();
   }
 
   @Override
-  public Crate readCrate(FolderStrategy strategy, Path source) throws IOException {
+  public Crate readCrate(ReadFolderStrategy strategy, Path source) throws IOException {
       return new CrateReader<>(strategy)
           .readCrate(source.toAbsolutePath().toString());
   }

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/FolderReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/FolderReaderTest.java
@@ -17,21 +17,21 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Nikola Tzotchev on 9.2.2022 г.
  * @version 1
  */
-class FolderReaderTest extends CrateReaderTest<String, FolderStrategy> {
-
+class FolderReaderTest implements CommonReaderTest<String, FolderStrategy>
+{
   @Override
-  protected void saveCrate(Crate crate, Path target) {
+  public void saveCrate(Crate crate, Path target) {
     Writers.newFolderWriter().save(crate, target.toAbsolutePath().toString());
     assertTrue(target.toFile().isDirectory());
   }
 
   @Override
-  protected Crate readCrate(Path source) throws IOException {
+  public Crate readCrate(Path source) throws IOException {
     return Readers.newFolderReader().readCrate(source.toAbsolutePath().toString());
   }
 
   @Override
-  protected FolderStrategy newReaderStrategyWithTmp(Path tmpDirectory, boolean useUuidSubfolder) {
+  public FolderStrategy newReaderStrategyWithTmp(Path tmpDirectory, boolean useUuidSubfolder) {
     // This strategy does not support a non-default temporary directory
     // and will always use the default one.
     // It also has no state we could make assertions on.
@@ -39,7 +39,7 @@ class FolderReaderTest extends CrateReaderTest<String, FolderStrategy> {
   }
 
   @Override
-  protected Crate readCrate(FolderStrategy strategy, Path source) throws IOException {
+  public Crate readCrate(FolderStrategy strategy, Path source) throws IOException {
       return new CrateReader<>(strategy)
           .readCrate(source.toAbsolutePath().toString());
   }

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/FolderReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/FolderReaderTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class FolderReaderTest implements CommonReaderTest<String, FolderStrategy>
 {
   @Override
-  public void saveCrate(Crate crate, Path target) {
+  public void saveCrate(Crate crate, Path target) throws IOException {
     Writers.newFolderWriter().save(crate, target.toAbsolutePath().toString());
     assertTrue(target.toFile().isDirectory());
   }

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/RoCrateReaderSpec12Test.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/RoCrateReaderSpec12Test.java
@@ -3,6 +3,7 @@ package edu.kit.datamanager.ro_crate.reader;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.util.stream.StreamSupport;
 
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,7 @@ public class RoCrateReaderSpec12Test {
      * https://www.researchobject.org/ro-crate/1.2-DRAFT/profiles.html#declaring-conformance-of-an-ro-crate-profile
      */
     @Test
-    void testReadingCrateWithConformsToArray() {
+    void testReadingCrateWithConformsToArray() throws IOException {
         String path = this.getClass().getResource("/crates/spec-1.2-DRAFT/minimal-with-conformsTo-Array").getPath();
         Crate crate = Readers.newFolderReader().readCrate(path);
         JsonNode conformsTo = crate.getJsonDescriptor().getProperty("conformsTo");

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/TestableReaderStrategy.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/TestableReaderStrategy.java
@@ -1,0 +1,50 @@
+package edu.kit.datamanager.ro_crate.reader;
+
+import edu.kit.datamanager.ro_crate.Crate;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Base Interface for methods required to test all reader strategies.
+ *
+ * @param <SOURCE_T> the source type the strategy reads from.
+ * @param <READER_STRATEGY> the type of the reader strategy.
+ */
+interface TestableReaderStrategy<SOURCE_T, READER_STRATEGY extends GenericReaderStrategy<SOURCE_T>> {
+    /**
+     * Saves the crate with the writer fitting to the reader of {@link #readCrate(Path)}.
+     *
+     * @param crate the crate to save
+     * @param target the target path to the save location
+     * @throws IOException if an error occurs while saving the crate
+     */
+    void saveCrate(Crate crate, Path target) throws IOException;
+
+    /**
+     * Reads the crate with the reader fitting to the writer of {@link #saveCrate(Crate, Path)}.
+     * @param source the source path to the crate
+     * @return the read crate
+     * @throws IOException if an error occurs while reading the crate
+     */
+    Crate readCrate(Path source) throws IOException;
+
+    /**
+     * Creates a new reader strategy with a non-default temporary directory (if supported, default otherwise).
+     *
+     * @param tmpDirectory the temporary directory to use
+     * @param useUuidSubfolder whether to create a UUID subfolder under the temporary directory
+     * @return a new reader strategy
+     */
+    READER_STRATEGY newReaderStrategyWithTmp(Path tmpDirectory, boolean useUuidSubfolder);
+
+    /**
+     * Reads the crate using the provided reader strategy.
+     *
+     * @param strategy the reader strategy to use
+     * @param source the source path to the crate
+     * @return the read crate
+     * @throws IOException if an error occurs while reading the crate
+     */
+    Crate readCrate(READER_STRATEGY strategy, Path source) throws IOException;
+}

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipReaderTest.java
@@ -2,65 +2,29 @@ package edu.kit.datamanager.ro_crate.reader;
 
 import edu.kit.datamanager.ro_crate.Crate;
 import edu.kit.datamanager.ro_crate.writer.Writers;
-import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
-import java.net.URL;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class ZipReaderTest extends CrateReaderTest<String, ZipStrategy> {
-
-    /**
-     * ELN Crates are zip files not fully compatible with the Ro-Crate standard
-     * in the sense that they must contain a single subfolder in the zip file
-     * which then contain a crate as specified by the Ro-Crate standard.
-     * <p>
-     * Here we test if we can read them using out ZipReader.
-     *
-     * @see <a href="https://github.com/TheELNConsortium/TheELNFileFormat"></a>
-     */
-    @ParameterizedTest
-    @ValueSource(strings = {
-            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/AI4Green/Export%20workbook-2024-08-27-export.eln",
-            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/OpenSemanticLab/MinimalExample.osl.eln",
-            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/PASTA/PASTA.eln",
-            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/RSpace/RSpace-2023-12-08-14-44-xml-SELECTION-c0bEtpHcnNe-HA.eln",
-            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/SampleDB/sampledb_export.eln",
-            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/elabftw/export.eln",
-            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/kadi4mat/records-example.eln",
-            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/kadi4mat/collections-example.eln"
-    })
-    void testReadElnCrates(String urlStr, @TempDir Path tmp) throws IOException {
-        // Download the ELN file
-        URL url = new URL(urlStr);
-        Path elnFile = tmp.resolve("downloaded.eln");
-        FileUtils.copyURLToFile(url, elnFile.toFile(), 10000, 10000);
-        assertTrue(elnFile.toFile().exists());
-
-        // Read the crate from the downloaded file
-        Crate read = this.readCrate(elnFile);
-        assertNotNull(read);
-        assertFalse(read.getAllDataEntities().isEmpty());
-    }
-
+class ZipReaderTest implements
+        CommonReaderTest<String, ZipStrategy>,
+        ElnFileFormatTest<String, ZipStrategy>
+{
     @Override
-    protected void saveCrate(Crate crate, Path target) {
+    public void saveCrate(Crate crate, Path target) {
         Writers.newZipPathWriter().save(crate, target.toAbsolutePath().toString());
         assertTrue(target.toFile().isFile());
     }
 
     @Override
-    protected Crate readCrate(Path source) throws IOException {
+    public Crate readCrate(Path source) throws IOException {
         return Readers.newZipPathReader().readCrate(source.toAbsolutePath().toString());
     }
 
     @Override
-    protected ZipStrategy newReaderStrategyWithTmp(Path tmpDirectory, boolean useUuidSubfolder) {
+    public ZipStrategy newReaderStrategyWithTmp(Path tmpDirectory, boolean useUuidSubfolder) {
         ZipStrategy strategy = new ZipStrategy(tmpDirectory, useUuidSubfolder);
         assertFalse(strategy.isExtracted());
         if (useUuidSubfolder) {
@@ -73,7 +37,7 @@ class ZipReaderTest extends CrateReaderTest<String, ZipStrategy> {
     }
 
     @Override
-    protected Crate readCrate(ZipStrategy strategy, Path source) throws IOException {
+    public Crate readCrate(ZipStrategy strategy, Path source) throws IOException {
         Crate importedCrate = new CrateReader<>(strategy)
                 .readCrate(source.toAbsolutePath().toString());
         assertTrue(strategy.isExtracted());

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipReaderTest.java
@@ -9,8 +9,8 @@ import java.nio.file.Path;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ZipReaderTest implements
-        CommonReaderTest<String, ZipStrategy>,
-        ElnFileFormatTest<String, ZipStrategy>
+        CommonReaderTest<String, ReadZipStrategy>,
+        ElnFileFormatTest<String, ReadZipStrategy>
 {
     @Override
     public void saveCrate(Crate crate, Path target) throws IOException {
@@ -24,8 +24,8 @@ class ZipReaderTest implements
     }
 
     @Override
-    public ZipStrategy newReaderStrategyWithTmp(Path tmpDirectory, boolean useUuidSubfolder) {
-        ZipStrategy strategy = new ZipStrategy(tmpDirectory, useUuidSubfolder);
+    public ReadZipStrategy newReaderStrategyWithTmp(Path tmpDirectory, boolean useUuidSubfolder) {
+        ReadZipStrategy strategy = new ReadZipStrategy(tmpDirectory, useUuidSubfolder);
         assertFalse(strategy.isExtracted());
         if (useUuidSubfolder) {
             assertEquals(strategy.getTemporaryFolder().getFileName().toString(), strategy.getID());
@@ -37,7 +37,7 @@ class ZipReaderTest implements
     }
 
     @Override
-    public Crate readCrate(ZipStrategy strategy, Path source) throws IOException {
+    public Crate readCrate(ReadZipStrategy strategy, Path source) throws IOException {
         Crate importedCrate = new CrateReader<>(strategy)
                 .readCrate(source.toAbsolutePath().toString());
         assertTrue(strategy.isExtracted());

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipReaderTest.java
@@ -13,7 +13,7 @@ class ZipReaderTest implements
         ElnFileFormatTest<String, ZipStrategy>
 {
     @Override
-    public void saveCrate(Crate crate, Path target) {
+    public void saveCrate(Crate crate, Path target) throws IOException {
         Writers.newZipPathWriter().save(crate, target.toAbsolutePath().toString());
         assertTrue(target.toFile().isFile());
     }

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipReaderTest.java
@@ -2,13 +2,51 @@ package edu.kit.datamanager.ro_crate.reader;
 
 import edu.kit.datamanager.ro_crate.Crate;
 import edu.kit.datamanager.ro_crate.writer.Writers;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class ZipReaderTest extends CrateReaderTest<String, ZipStrategy> {
+
+    /**
+     * ELN Crates are zip files not fully compatible with the Ro-Crate standard
+     * in the sense that they must contain a single subfolder in the zip file
+     * which then contain a crate as specified by the Ro-Crate standard.
+     * <p>
+     * Here we test if we can read them using out ZipReader.
+     *
+     * @see <a href="https://github.com/TheELNConsortium/TheELNFileFormat"></a>
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/AI4Green/Export%20workbook-2024-08-27-export.eln",
+            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/OpenSemanticLab/MinimalExample.osl.eln",
+            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/PASTA/PASTA.eln",
+            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/RSpace/RSpace-2023-12-08-14-44-xml-SELECTION-c0bEtpHcnNe-HA.eln",
+            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/SampleDB/sampledb_export.eln",
+            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/elabftw/export.eln",
+            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/kadi4mat/records-example.eln",
+            "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/kadi4mat/collections-example.eln"
+    })
+    void testReadElnCrates(String urlStr, @TempDir Path tmp) throws IOException {
+        // Download the ELN file
+        URL url = new URL(urlStr);
+        Path elnFile = tmp.resolve("downloaded.eln");
+        FileUtils.copyURLToFile(url, elnFile.toFile(), 10000, 10000);
+        assertTrue(elnFile.toFile().exists());
+
+        // Read the crate from the downloaded file
+        Crate read = this.readCrate(elnFile);
+        assertNotNull(read);
+        assertFalse(read.getAllDataEntities().isEmpty());
+    }
 
     @Override
     protected void saveCrate(Crate crate, Path target) {

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipStreamReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipStreamReaderTest.java
@@ -9,20 +9,23 @@ import java.nio.file.Path;
 import static org.junit.jupiter.api.Assertions.*;
 
 
-class ZipStreamReaderTest extends CrateReaderTest<InputStream, ZipStreamStrategy> {
+class ZipStreamReaderTest implements
+        CommonReaderTest<InputStream, ZipStreamStrategy>,
+        ElnFileFormatTest<InputStream, ZipStreamStrategy>
+{
     @Override
-    protected void saveCrate(Crate crate, Path target) throws IOException {
+    public void saveCrate(Crate crate, Path target) throws IOException {
         Writers.newZipStreamWriter().save(crate, new FileOutputStream(target.toFile()));
         assertTrue(target.toFile().isFile());
     }
 
     @Override
-    protected Crate readCrate(Path source) throws IOException {
+    public Crate readCrate(Path source) throws IOException {
         return Readers.newZipStreamReader().readCrate(new FileInputStream(source.toFile()));
     }
 
     @Override
-    protected ZipStreamStrategy newReaderStrategyWithTmp(Path tmpDirectory, boolean useUuidSubfolder) {
+    public ZipStreamStrategy newReaderStrategyWithTmp(Path tmpDirectory, boolean useUuidSubfolder) {
         ZipStreamStrategy strategy = new ZipStreamStrategy(tmpDirectory, useUuidSubfolder);
         assertFalse(strategy.isExtracted());
         if (useUuidSubfolder) {
@@ -35,7 +38,7 @@ class ZipStreamReaderTest extends CrateReaderTest<InputStream, ZipStreamStrategy
     }
 
     @Override
-    protected Crate readCrate(ZipStreamStrategy strategy, Path source) throws IOException {
+    public Crate readCrate(ZipStreamStrategy strategy, Path source) throws IOException {
         Crate importedCrate = new CrateReader<>(strategy)
                 .readCrate(new FileInputStream(source.toFile()));
         assertTrue(strategy.isExtracted());

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipStreamReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipStreamReaderTest.java
@@ -11,8 +11,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 
 class ZipStreamReaderTest implements
-        CommonReaderTest<InputStream, ZipStreamStrategy>,
-        ElnFileFormatTest<InputStream, ZipStreamStrategy>
+        CommonReaderTest<InputStream, ReadZipStreamStrategy>,
+        ElnFileFormatTest<InputStream, ReadZipStreamStrategy>
 {
     /**
      * At the point of writing this test,
@@ -39,8 +39,8 @@ class ZipStreamReaderTest implements
     }
 
     @Override
-    public ZipStreamStrategy newReaderStrategyWithTmp(Path tmpDirectory, boolean useUuidSubfolder) {
-        ZipStreamStrategy strategy = new ZipStreamStrategy(tmpDirectory, useUuidSubfolder);
+    public ReadZipStreamStrategy newReaderStrategyWithTmp(Path tmpDirectory, boolean useUuidSubfolder) {
+        ReadZipStreamStrategy strategy = new ReadZipStreamStrategy(tmpDirectory, useUuidSubfolder);
         assertFalse(strategy.isExtracted());
         if (useUuidSubfolder) {
             assertEquals(strategy.getTemporaryFolder().getFileName().toString(), strategy.getID());
@@ -52,7 +52,7 @@ class ZipStreamReaderTest implements
     }
 
     @Override
-    public Crate readCrate(ZipStreamStrategy strategy, Path source) throws IOException {
+    public Crate readCrate(ReadZipStreamStrategy strategy, Path source) throws IOException {
         Crate importedCrate = new CrateReader<>(strategy)
                 .readCrate(new FileInputStream(source.toFile()));
         assertTrue(strategy.isExtracted());

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipStreamReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipStreamReaderTest.java
@@ -5,6 +5,7 @@ import edu.kit.datamanager.ro_crate.writer.Writers;
 
 import java.io.*;
 import java.nio.file.Path;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -13,6 +14,19 @@ class ZipStreamReaderTest implements
         CommonReaderTest<InputStream, ZipStreamStrategy>,
         ElnFileFormatTest<InputStream, ZipStreamStrategy>
 {
+    /**
+     * At the point of writing this test,
+     *  these files are in a zip format which cannot be read in streaming mode
+     */
+    @Override
+    public boolean isInBlacklist(String input) {
+        return Set.of(
+                "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/kadi4mat/records-example.eln",
+                "https://github.com/TheELNConsortium/TheELNFileFormat/raw/refs/heads/master/examples/kadi4mat/collections-example.eln"
+        )
+                .contains(input);
+    }
+
     @Override
     public void saveCrate(Crate crate, Path target) throws IOException {
         Writers.newZipStreamWriter().save(crate, new FileOutputStream(target.toFile()));

--- a/src/test/java/edu/kit/datamanager/ro_crate/util/FileSystemUtilTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/util/FileSystemUtilTest.java
@@ -1,0 +1,31 @@
+package edu.kit.datamanager.ro_crate.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FileSystemUtilTest {
+
+    @ValueSource(strings = {
+            "test",
+            "test/",
+            "test/test",
+            "test/test/",
+            "test/test/test",
+            "test/test/test/"
+    })
+    @ParameterizedTest
+    void ensureTrailingSlash(String value) {
+        String result = FileSystemUtil.ensureTrailingSlash(value);
+        assertTrue(result.endsWith("/"), "The result should end with a trailing slash.");
+    }
+
+    @SuppressWarnings("ConstantValue")
+    @Test
+    void ensureTrailingSlashNull() {
+        String result = FileSystemUtil.ensureTrailingSlash(null);
+        assertNull(result, "The result should be null.");
+    }
+}

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/CommonWriterTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/CommonWriterTest.java
@@ -1,20 +1,14 @@
 package edu.kit.datamanager.ro_crate.writer;
 
-import edu.kit.datamanager.ro_crate.Crate;
 import edu.kit.datamanager.ro_crate.HelpFunctions;
 import edu.kit.datamanager.ro_crate.RoCrate;
 import edu.kit.datamanager.ro_crate.entities.data.DataSetEntity;
-import edu.kit.datamanager.ro_crate.entities.data.FileEntity;
-import edu.kit.datamanager.ro_crate.preview.AutomaticPreview;
-import edu.kit.datamanager.ro_crate.preview.PreviewGenerator;
-import net.lingala.zip4j.ZipFile;
+
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -22,16 +16,7 @@ import java.nio.file.Path;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-abstract class CrateWriterTest {
-
-    /**
-     * Saves the crate with the writer fitting to this test class.
-     *
-     * @param crate the crate to save
-     * @param target the target path to the save location
-     * @throws IOException if an error occurs while saving the crate
-     */
-    abstract protected void saveCrate(Crate crate, Path target) throws IOException;
+interface CommonWriterTest extends TestableWriterStrategy {
 
     /**
      * Test where the writer needs to rename files or folders in order to make a valid crate.
@@ -41,11 +26,11 @@ abstract class CrateWriterTest {
      * @throws IOException if an error occurs while writing the crate
      */
     @Test
-    void testFilesBeingAdjusted(@TempDir Path tempDir) throws IOException {
+    default void testFilesBeingAdjusted(@TempDir Path tempDir) throws IOException {
         Path correctCrate = tempDir.resolve("compare_with_me");
         Path pathToFile = correctCrate.resolve("you-will-need-to-rename-this-file.ai");
         Path pathToDir = correctCrate.resolve("you-will-need-to-rename-this-dir");
-        this.createManualCrateStructure(correctCrate, pathToFile, pathToDir);
+        createManualCrateStructure(correctCrate, pathToFile, pathToDir);
 
         Path writtenCrate = tempDir.resolve("written-crate");
         Path extractionPath = tempDir.resolve("checkMe");
@@ -60,11 +45,11 @@ abstract class CrateWriterTest {
                     )
                     .build();
             this.saveCrate(builtCrate, writtenCrate);
-            this.ensureCrateIsExtractedIn(writtenCrate, extractionPath);
+            ensureCrateIsExtractedIn(writtenCrate, extractionPath);
         }
 
-        printFileTree(correctCrate);
-        printFileTree(extractionPath);
+        HelpFunctions.printFileTree(correctCrate);
+        HelpFunctions.printFileTree(extractionPath);
 
         // The actual file name should **not** appear in the crate
         String fileName = pathToFile.getFileName().toString();
@@ -111,7 +96,7 @@ abstract class CrateWriterTest {
      * @throws IOException if an error occurs while writing the crate
      */
     @Test
-    void testWritingMakesCopy(@TempDir Path tempDir) throws IOException {
+    default void testWritingMakesCopy(@TempDir Path tempDir) throws IOException {
         // We need a correct directory to compare with.
         // It is built manually to ensure we meet our expectations.
         // Reader-writer-consistency is tested at {@link CrateReaderTest}
@@ -119,7 +104,7 @@ abstract class CrateWriterTest {
         Path pathToFile = correctCrate.resolve("cp7glop.ai");
         Path pathToDir = correctCrate.resolve("lots_of_little_files");
 
-        this.createManualCrateStructure(correctCrate, pathToFile, pathToDir);
+        createManualCrateStructure(correctCrate, pathToFile, pathToDir);
 
         // Now use the builder to build the same crate independently.
         // The files will be reused (we need a place to take a copy from)
@@ -130,9 +115,9 @@ abstract class CrateWriterTest {
 
         // extract the zip file to a temporary directory
         Path extractionPath = tempDir.resolve("extracted_for_testing");
-        this.ensureCrateIsExtractedIn(pathToZip, extractionPath);
-        printFileTree(correctCrate);
-        printFileTree(extractionPath);
+        ensureCrateIsExtractedIn(pathToZip, extractionPath);
+        HelpFunctions.printFileTree(correctCrate);
+        HelpFunctions.printFileTree(extractionPath);
 
         // compare the extracted directory with the correct one
         assertTrue(HelpFunctions.compareTwoDir(
@@ -151,12 +136,12 @@ abstract class CrateWriterTest {
      * @throws IOException if an error occurs while writing the crate
      */
     @Test
-    void testWritingOnlyConsidersAddedFiles(@TempDir Path tempDir) throws IOException {
+    default void testWritingOnlyConsidersAddedFiles(@TempDir Path tempDir) throws IOException {
         Path correctCrate = tempDir.resolve("compare_with_me");
         Path pathToFile = correctCrate.resolve("cp7glop.ai");
         Path pathToDir = correctCrate.resolve("lots_of_little_files");
 
-        this.createManualCrateStructure(correctCrate, pathToFile, pathToDir);
+        createManualCrateStructure(correctCrate, pathToFile, pathToDir);
         {
             // This file is not part of the crate, and should therefore not be present
             Path falseFile = correctCrate.resolve("new");
@@ -176,8 +161,8 @@ abstract class CrateWriterTest {
         // extract and compare
         Path extractionPath = tempDir.resolve("extracted_for_testing");
         ensureCrateIsExtractedIn(pathToZip, extractionPath);
-        printFileTree(correctCrate);
-        printFileTree(extractionPath);
+        HelpFunctions.printFileTree(correctCrate);
+        HelpFunctions.printFileTree(extractionPath);
 
         assertFalse(HelpFunctions.compareTwoDir(
                 correctCrate.toFile(),
@@ -186,117 +171,5 @@ abstract class CrateWriterTest {
         HelpFunctions.compareCrateJsonToFileInResources(
                 roCrate,
                 "/json/crate/fileAndDir.json");
-    }
-
-    /**
-     * Prints the file tree of the given directory for debugging and understanding
-     * a test more quickly.
-     *
-     * @param directoryToPrint the directory to print
-     * @throws IOException if an error occurs while printing the file tree
-     */
-    @SuppressWarnings("resource")
-    protected static void printFileTree(Path directoryToPrint) throws IOException {
-        // Print all files recursively in a tree structure for debugging
-        System.out.printf("Files in %s:%n", directoryToPrint.getFileName().toString());
-        Files.walk(directoryToPrint)
-                .forEach(path -> {
-                    if (!path.toAbsolutePath().equals(directoryToPrint.toAbsolutePath())) {
-                        int depth = path.relativize(directoryToPrint).getNameCount();
-                        String prefix = "  ".repeat(depth);
-                        System.out.printf("%s%s%s%n", prefix, "└── ", path.getFileName());
-                    }
-                });
-    }
-
-    /**
-     * Ensures the crate is in extracted form in the given path.
-     *
-     * @param pathToCrate       the path to the crate, may not be a folder yet
-     * @param expectedPath      the path where the crate should be in extracted form
-     * @throws IOException if an error occurs while extracting the crate
-     */
-    protected void ensureCrateIsExtractedIn(Path pathToCrate, Path expectedPath) throws IOException {
-        try (ZipFile zf = new ZipFile(pathToCrate.toFile())) {
-            zf.extractAll(expectedPath.toFile().getAbsolutePath());
-        }
-    }
-
-    /**
-     * Creates a crate structure manually.
-     *
-     * @param correctCrate the path to the crate
-     * @param pathToFile   the path to the file
-     * @param pathToDir    the path to the directory
-     * @throws IOException if an error occurs while creating the crate structure
-     */
-    protected void createManualCrateStructure(Path correctCrate, Path pathToFile, Path pathToDir) throws IOException {
-        FileUtils.forceMkdir(correctCrate.toFile());
-        InputStream fileJson = ZipStreamStrategyTest.class
-                .getResourceAsStream("/json/crate/fileAndDir.json");
-        Assertions.assertNotNull(fileJson);
-        // fill the directory with expected files and dirs
-        // starting with the .json of our crate
-        Path json = correctCrate.resolve("ro-crate-metadata.json");
-        FileUtils.copyInputStreamToFile(fileJson, json.toFile());
-        // create preview
-        PreviewGenerator.generatePreview(correctCrate.toFile().getAbsolutePath());
-        // create the files and directories
-        FileUtils.writeStringToFile(pathToFile.toFile(), "content of Local File", Charset.defaultCharset());
-        // creates the directory and a subdirectory
-        Path subdir = pathToDir.resolve("subdir");
-        FileUtils.forceMkdir(subdir.toFile());
-        FileUtils.writeStringToFile(
-                subdir.resolve("subsubfirst.txt").toFile(),
-                "content of subsub file in subsubdir",
-                Charset.defaultCharset());
-        FileUtils.writeStringToFile(
-                pathToDir.resolve("first.txt").toFile(),
-                "content of first file in dir",
-                Charset.defaultCharset());
-        FileUtils.writeStringToFile(
-                pathToDir.resolve("second.txt").toFile(),
-                "content of second file in dir",
-                Charset.defaultCharset());
-        FileUtils.writeStringToFile(
-                pathToDir.resolve("third.txt").toFile(),
-                "content of third file in dir",
-                Charset.defaultCharset());
-    }
-
-    /**
-     * Creates a crate resembling the one we manually create in these tests.
-     *
-     * @param pathToFile      the file to add
-     * @param pathToSubdir the directory to add
-     * @return the crate builder
-     */
-    protected RoCrate.RoCrateBuilder getCrateWithFileAndDir(Path pathToFile, Path pathToSubdir) {
-        return new RoCrate.RoCrateBuilder(
-                "Example RO-Crate",
-                "The RO-Crate Root Data Entity",
-                "2024",
-                "https://creativecommons.org/licenses/by-nc-sa/3.0/au/"
-        )
-                .addDataEntity(
-                        new FileEntity.FileEntityBuilder()
-                                .addProperty("name", "Diagram showing trend to increase")
-                                .addProperty("contentSize", "383766")
-                                .addProperty("description", "Illustrator file for Glop Pot")
-                                .setEncodingFormat("application/pdf")
-                                .setLocationWithExceptions(pathToFile)
-                                .setId("cp7glop.ai")
-                                .build()
-                )
-                .addDataEntity(
-                        new DataSetEntity.DataSetBuilder()
-                                .addProperty("name", "Too many files")
-                                .addProperty("description",
-                                        "This directory contains many small files, that we're not going to describe in detail.")
-                                .setLocationWithExceptions(pathToSubdir)
-                                .setId("lots_of_little_files/")
-                                .build()
-                )
-                .setPreview(new AutomaticPreview());
     }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/ElnFileFormatTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/ElnFileFormatTest.java
@@ -1,0 +1,70 @@
+package edu.kit.datamanager.ro_crate.writer;
+
+import edu.kit.datamanager.ro_crate.Crate;
+import edu.kit.datamanager.ro_crate.HelpFunctions;
+import edu.kit.datamanager.ro_crate.RoCrate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public interface ElnFileFormatTest extends TestableWriterStrategy {
+
+    /**
+     * Write in ELN format style, meaning with a subfolder in the zip file.
+     *
+     * @param crate the crate to write
+     * @param target the target path to the save location
+     * @throws IOException if an error occurs
+     */
+    void saveCrateElnStyle(Crate crate, Path target) throws IOException;
+
+    @Test
+    default void testMakesElnStyleCrate(@TempDir Path tempDir) throws IOException {
+        // We need a correct directory to compare with.
+        // It is built manually to ensure we meet our expectations.
+        // Reader-writer-consistency is tested at {@link CrateReaderTest}
+
+        // We compare the ELN style like this:
+        // tempDir
+        //   └── compare_with_me
+        //       └── crate-subfolder
+        //           ├── ...
+        //   └── extracted_for_testing
+        //       └── crate-subfolder
+        //           ├── ...
+        String crateName = "crate-subfolder";
+        Path correctCrate = tempDir
+                .resolve("compare_with_me")
+                .resolve(crateName);
+        Path pathToFile = correctCrate.resolve("cp7glop.ai");
+        Path pathToDir = correctCrate.resolve("lots_of_little_files");
+
+        createManualCrateStructure(correctCrate, pathToFile, pathToDir);
+
+        // Now use the builder to build the same crate independently.
+        // The files will be reused (we need a place to take a copy from)
+        RoCrate builtCrate = getCrateWithFileAndDir(pathToFile, pathToDir).build();
+
+        Path pathToZip = tempDir.resolve("%s.eln".formatted(crateName));
+        this.saveCrateElnStyle(builtCrate, pathToZip);
+
+        // extract the zip file to a temporary directory
+        Path extractionPath = tempDir.resolve("extracted_for_testing");
+        ensureCrateIsExtractedIn(pathToZip, extractionPath);
+        HelpFunctions.printFileTree(correctCrate);
+        HelpFunctions.printFileTree(extractionPath);
+
+        // compare the extracted directory with the correct one
+        assertTrue(HelpFunctions.compareTwoDir(
+                correctCrate.toFile(),
+                extractionPath.toFile()));
+        HelpFunctions.compareCrateJsonToFileInResources(
+                builtCrate,
+                "/json/crate/fileAndDir.json");
+    }
+}

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/ElnFileWriterTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/ElnFileWriterTest.java
@@ -4,6 +4,7 @@ import edu.kit.datamanager.ro_crate.Crate;
 import edu.kit.datamanager.ro_crate.HelpFunctions;
 import edu.kit.datamanager.ro_crate.RoCrate;
 
+import edu.kit.datamanager.ro_crate.reader.CommonReaderTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -12,16 +13,25 @@ import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public interface ElnFileFormatTest extends TestableWriterStrategy {
+public interface ElnFileWriterTest extends TestableWriterStrategy {
 
     /**
      * Write in ELN format style, meaning with a subfolder in the zip file.
+     * Must use {@link ElnFormatWriter#usingElnStyle()}.
      *
      * @param crate the crate to write
      * @param target the target path to the save location
      * @throws IOException if an error occurs
      */
     void saveCrateElnStyle(Crate crate, Path target) throws IOException;
+
+    /**
+     * Same as {@link #saveCrateElnStyle(Crate, Path)} but with the alias
+     * {@link  ElnFormatWriter#withRootSubdirectory()}.
+     * @param crate the crate to write
+     * @param target the target path to the save location
+     */
+    void saveCrateSubdirectoryStyle(RoCrate crate, Path target) throws IOException;
 
     @Test
     default void testMakesElnStyleCrate(@TempDir Path tempDir) throws IOException {
@@ -66,5 +76,17 @@ public interface ElnFileFormatTest extends TestableWriterStrategy {
         HelpFunctions.compareCrateJsonToFileInResources(
                 builtCrate,
                 "/json/crate/fileAndDir.json");
+    }
+
+    @Test
+    default void testAlias(@TempDir Path tmpDir) throws IOException {
+        Path zip = tmpDir.resolve("test.eln").toAbsolutePath();
+        RoCrate crate = CommonReaderTest.newBaseCrate().build();
+
+        this.saveCrateSubdirectoryStyle(crate, zip);
+
+        assertTrue(zip.toFile().exists(), "The zip file should exist");
+        Path extractedPath = tmpDir.resolve("extracted");
+        ensureCrateIsExtractedIn(zip, extractedPath);
     }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/FolderWriterTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/FolderWriterTest.java
@@ -11,16 +11,16 @@ import org.apache.commons.io.FileUtils;
  * @author Nikola Tzotchev on 9.2.2022 г.
  * @version 1
  */
-class FolderWriterTest extends CrateWriterTest {
+class FolderWriterTest implements CommonWriterTest {
 
     @Override
-    protected void saveCrate(Crate crate, Path target) throws IOException {
+    public void saveCrate(Crate crate, Path target) throws IOException {
         Writers.newFolderWriter()
                 .save(crate, target.toAbsolutePath().toString());
     }
 
     @Override
-    protected void ensureCrateIsExtractedIn(Path pathToCrate, Path expectedPath) throws IOException {
+    public void ensureCrateIsExtractedIn(Path pathToCrate, Path expectedPath) throws IOException {
         FileUtils.copyDirectory(pathToCrate.toFile(), expectedPath.toFile());
     }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/TestableWriterStrategy.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/TestableWriterStrategy.java
@@ -1,0 +1,121 @@
+package edu.kit.datamanager.ro_crate.writer;
+
+import edu.kit.datamanager.ro_crate.Crate;
+import edu.kit.datamanager.ro_crate.RoCrate;
+import edu.kit.datamanager.ro_crate.entities.data.DataSetEntity;
+import edu.kit.datamanager.ro_crate.entities.data.FileEntity;
+import edu.kit.datamanager.ro_crate.preview.AutomaticPreview;
+import edu.kit.datamanager.ro_crate.preview.PreviewGenerator;
+import net.lingala.zip4j.ZipFile;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Assertions;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+
+/**
+ * Base Interface for methods required to test all writer strategies.
+ */
+interface TestableWriterStrategy {
+    /**
+     * Saves the crate with the writer fitting to this test class.
+     *
+     * @param crate the crate to save
+     * @param target the target path to the save location
+     * @throws IOException if an error occurs while saving the crate
+     */
+    void saveCrate(Crate crate, Path target) throws IOException;
+
+    /**
+     * Ensures the crate is in extracted form in the given path.
+     *
+     * @param pathToCrate       the path to the crate, may not be a folder yet
+     * @param expectedPath      the path where the crate should be in extracted form
+     * @throws IOException if an error occurs while extracting the crate
+     */
+    default void ensureCrateIsExtractedIn(Path pathToCrate, Path expectedPath) throws IOException {
+        try (ZipFile zf = new ZipFile(pathToCrate.toFile())) {
+            zf.extractAll(expectedPath.toFile().getAbsolutePath());
+        }
+    }
+
+    /**
+     * Creates a crate structure manually.
+     *
+     * @param correctCrate the path to the crate
+     * @param pathToFile   the path to the file
+     * @param pathToDir    the path to the directory
+     * @throws IOException if an error occurs while creating the crate structure
+     */
+    default void createManualCrateStructure(Path correctCrate, Path pathToFile, Path pathToDir) throws IOException {
+        FileUtils.forceMkdir(correctCrate.toFile());
+        InputStream fileJson = ZipStreamStrategyTest.class
+                .getResourceAsStream("/json/crate/fileAndDir.json");
+        Assertions.assertNotNull(fileJson);
+        // fill the directory with expected files and dirs
+        // starting with the .json of our crate
+        Path json = correctCrate.resolve("ro-crate-metadata.json");
+        FileUtils.copyInputStreamToFile(fileJson, json.toFile());
+        // create preview
+        PreviewGenerator.generatePreview(correctCrate.toFile().getAbsolutePath());
+        // create the files and directories
+        FileUtils.writeStringToFile(pathToFile.toFile(), "content of Local File", Charset.defaultCharset());
+        // creates the directory and a subdirectory
+        Path subdir = pathToDir.resolve("subdir");
+        FileUtils.forceMkdir(subdir.toFile());
+        FileUtils.writeStringToFile(
+                subdir.resolve("subsubfirst.txt").toFile(),
+                "content of subsub file in subsubdir",
+                Charset.defaultCharset());
+        FileUtils.writeStringToFile(
+                pathToDir.resolve("first.txt").toFile(),
+                "content of first file in dir",
+                Charset.defaultCharset());
+        FileUtils.writeStringToFile(
+                pathToDir.resolve("second.txt").toFile(),
+                "content of second file in dir",
+                Charset.defaultCharset());
+        FileUtils.writeStringToFile(
+                pathToDir.resolve("third.txt").toFile(),
+                "content of third file in dir",
+                Charset.defaultCharset());
+    }
+
+    /**
+     * Creates a crate resembling the one we manually create in these tests.
+     *
+     * @param pathToFile      the file to add
+     * @param pathToSubdir the directory to add
+     * @return the crate builder
+     */
+    default RoCrate.RoCrateBuilder getCrateWithFileAndDir(Path pathToFile, Path pathToSubdir) {
+        return new RoCrate.RoCrateBuilder(
+                "Example RO-Crate",
+                "The RO-Crate Root Data Entity",
+                "2024",
+                "https://creativecommons.org/licenses/by-nc-sa/3.0/au/"
+        )
+                .addDataEntity(
+                        new FileEntity.FileEntityBuilder()
+                                .addProperty("name", "Diagram showing trend to increase")
+                                .addProperty("contentSize", "383766")
+                                .addProperty("description", "Illustrator file for Glop Pot")
+                                .setEncodingFormat("application/pdf")
+                                .setLocationWithExceptions(pathToFile)
+                                .setId("cp7glop.ai")
+                                .build()
+                )
+                .addDataEntity(
+                        new DataSetEntity.DataSetBuilder()
+                                .addProperty("name", "Too many files")
+                                .addProperty("description",
+                                        "This directory contains many small files, that we're not going to describe in detail.")
+                                .setLocationWithExceptions(pathToSubdir)
+                                .setId("lots_of_little_files/")
+                                .build()
+                )
+                .setPreview(new AutomaticPreview());
+    }
+}

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/TestableWriterStrategy.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/TestableWriterStrategy.java
@@ -51,7 +51,7 @@ interface TestableWriterStrategy {
      */
     default void createManualCrateStructure(Path correctCrate, Path pathToFile, Path pathToDir) throws IOException {
         FileUtils.forceMkdir(correctCrate.toFile());
-        InputStream fileJson = ZipStreamStrategyTest.class
+        InputStream fileJson = ZipStreamWriterTest.class
                 .getResourceAsStream("/json/crate/fileAndDir.json");
         Assertions.assertNotNull(fileJson);
         // fill the directory with expected files and dirs

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipStreamStrategyTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipStreamStrategyTest.java
@@ -4,16 +4,32 @@ import java.io.*;
 import java.nio.file.Path;
 
 import edu.kit.datamanager.ro_crate.Crate;
+import edu.kit.datamanager.ro_crate.RoCrate;
 
 /**
  * @author jejkal
  */
-class ZipStreamStrategyTest implements CommonWriterTest {
+class ZipStreamStrategyTest implements
+        CommonWriterTest,
+        ElnFileWriterTest
+{
 
   @Override
   public void saveCrate(Crate crate, Path target) throws IOException {
     try (FileOutputStream stream = new FileOutputStream(target.toFile())) {
       Writers.newZipStreamWriter().save(crate, stream);
     }
+  }
+
+  @Override
+  public void saveCrateElnStyle(Crate crate, Path target) throws IOException {
+    new CrateWriter<>(new ZipStreamStrategy().usingElnStyle())
+            .save(crate, target.toAbsolutePath().toString());
+  }
+
+  @Override
+  public void saveCrateSubdirectoryStyle(RoCrate crate, Path target) throws IOException {
+    new CrateWriter<>(new ZipStreamStrategy().withRootSubdirectory())
+            .save(crate, target.toString());
   }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipStreamStrategyTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipStreamStrategyTest.java
@@ -23,13 +23,13 @@ class ZipStreamStrategyTest implements
 
   @Override
   public void saveCrateElnStyle(Crate crate, Path target) throws IOException {
-    new CrateWriter<>(new ZipStreamStrategy().usingElnStyle())
+    new CrateWriter<>(new WriteZipStreamStrategy().usingElnStyle())
             .save(crate, new FileOutputStream(target.toFile()));
   }
 
   @Override
   public void saveCrateSubdirectoryStyle(RoCrate crate, Path target) throws IOException {
-    new CrateWriter<>(new ZipStreamStrategy().withRootSubdirectory())
+    new CrateWriter<>(new WriteZipStreamStrategy().withRootSubdirectory())
             .save(crate, new FileOutputStream(target.toFile()));
   }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipStreamStrategyTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipStreamStrategyTest.java
@@ -24,12 +24,12 @@ class ZipStreamStrategyTest implements
   @Override
   public void saveCrateElnStyle(Crate crate, Path target) throws IOException {
     new CrateWriter<>(new ZipStreamStrategy().usingElnStyle())
-            .save(crate, target.toAbsolutePath().toString());
+            .save(crate, new FileOutputStream(target.toFile()));
   }
 
   @Override
   public void saveCrateSubdirectoryStyle(RoCrate crate, Path target) throws IOException {
     new CrateWriter<>(new ZipStreamStrategy().withRootSubdirectory())
-            .save(crate, target.toString());
+            .save(crate, new FileOutputStream(target.toFile()));
   }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipStreamStrategyTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipStreamStrategyTest.java
@@ -8,10 +8,10 @@ import edu.kit.datamanager.ro_crate.Crate;
 /**
  * @author jejkal
  */
-class ZipStreamStrategyTest extends CrateWriterTest {
+class ZipStreamStrategyTest implements CommonWriterTest {
 
   @Override
-  protected void saveCrate(Crate crate, Path target) throws IOException {
+  public void saveCrate(Crate crate, Path target) throws IOException {
     try (FileOutputStream stream = new FileOutputStream(target.toFile())) {
       Writers.newZipStreamWriter().save(crate, stream);
     }

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipStreamWriterTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipStreamWriterTest.java
@@ -9,7 +9,7 @@ import edu.kit.datamanager.ro_crate.RoCrate;
 /**
  * @author jejkal
  */
-class ZipStreamStrategyTest implements
+class ZipStreamWriterTest implements
         CommonWriterTest,
         ElnFileWriterTest
 {

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipWriterTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipWriterTest.java
@@ -6,8 +6,6 @@ import java.nio.file.Path;
 import edu.kit.datamanager.ro_crate.Crate;
 import edu.kit.datamanager.ro_crate.RoCrate;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 class ZipWriterTest implements
         CommonWriterTest,
         ElnFileWriterTest

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipWriterTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipWriterTest.java
@@ -5,10 +5,6 @@ import java.nio.file.Path;
 
 import edu.kit.datamanager.ro_crate.Crate;
 import edu.kit.datamanager.ro_crate.RoCrate;
-import edu.kit.datamanager.ro_crate.reader.CommonReaderTest;
-
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -24,13 +20,13 @@ class ZipWriterTest implements
 
     @Override
     public void saveCrateElnStyle(Crate crate, Path target) throws IOException {
-        new CrateWriter<>(new ZipStrategy().usingElnStyle())
+        new CrateWriter<>(new WriteZipStrategy().usingElnStyle())
                 .save(crate, target.toAbsolutePath().toString());
     }
 
     @Override
     public void saveCrateSubdirectoryStyle(RoCrate crate, Path target) throws IOException {
-        new CrateWriter<>(new ZipStrategy().withRootSubdirectory())
+        new CrateWriter<>(new WriteZipStrategy().withRootSubdirectory())
                 .save(crate, target.toString());
     }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipWriterTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipWriterTest.java
@@ -4,6 +4,13 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import edu.kit.datamanager.ro_crate.Crate;
+import edu.kit.datamanager.ro_crate.RoCrate;
+import edu.kit.datamanager.ro_crate.reader.CommonReaderTest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ZipWriterTest implements
         CommonWriterTest,
@@ -19,5 +26,18 @@ class ZipWriterTest implements
     public void saveCrateElnStyle(Crate crate, Path target) throws IOException {
         new CrateWriter<>(new ZipStrategy().usingElnStyle())
                 .save(crate, target.toAbsolutePath().toString());
+    }
+
+    @Test
+    public void testAlias(@TempDir Path tmpDir) throws IOException {
+        Path zip = tmpDir.resolve("test.eln").toAbsolutePath();
+        RoCrate crate = CommonReaderTest.newBaseCrate().build();
+
+        new CrateWriter<>(new ZipStrategy().withRootSubdirectory())
+                .save(crate, zip.toString());
+
+        assertTrue(zip.toFile().exists(), "The zip file should exist");
+        Path extractedPath = tmpDir.resolve("extracted");
+        ensureCrateIsExtractedIn(zip, extractedPath);
     }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipWriterTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipWriterTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ZipWriterTest implements
         CommonWriterTest,
-        ElnFileFormatTest
+        ElnFileWriterTest
 {
     @Override
     public void saveCrate(Crate crate, Path target) throws IOException {
@@ -28,16 +28,9 @@ class ZipWriterTest implements
                 .save(crate, target.toAbsolutePath().toString());
     }
 
-    @Test
-    public void testAlias(@TempDir Path tmpDir) throws IOException {
-        Path zip = tmpDir.resolve("test.eln").toAbsolutePath();
-        RoCrate crate = CommonReaderTest.newBaseCrate().build();
-
+    @Override
+    public void saveCrateSubdirectoryStyle(RoCrate crate, Path target) throws IOException {
         new CrateWriter<>(new ZipStrategy().withRootSubdirectory())
-                .save(crate, zip.toString());
-
-        assertTrue(zip.toFile().exists(), "The zip file should exist");
-        Path extractedPath = tmpDir.resolve("extracted");
-        ensureCrateIsExtractedIn(zip, extractedPath);
+                .save(crate, target.toString());
     }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipWriterTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipWriterTest.java
@@ -5,10 +5,19 @@ import java.nio.file.Path;
 
 import edu.kit.datamanager.ro_crate.Crate;
 
-class ZipWriterTest extends CrateWriterTest {
+class ZipWriterTest implements
+        CommonWriterTest,
+        ElnFileFormatTest
+{
     @Override
-    protected void saveCrate(Crate crate, Path target) throws IOException {
+    public void saveCrate(Crate crate, Path target) throws IOException {
         Writers.newZipPathWriter()
+                .save(crate, target.toAbsolutePath().toString());
+    }
+
+    @Override
+    public void saveCrateElnStyle(Crate crate, Path target) throws IOException {
+        new CrateWriter<>(new ZipStrategy().usingElnStyle())
                 .save(crate, target.toAbsolutePath().toString());
     }
 }


### PR DESCRIPTION
Closes #251 

See https://github.com/TheELNConsortium/TheELNFileFormat

From the view of RO-Crate Java these crates are zip crates with the special (incompatible) property that the crates are in a subfolder within the file.

This should be simple to add, but due to some weird Zip files, refactorings and deprecations this is a slightly larger task which adds also surprisigly larger amounts of code for testing and because I can't delete the deprecated code immediately.

## Support reading

- [x] Add a unit test if the readers already work with them, but as they assume a subfolder, this might be not the case.
- [x] Zip: Consider simply making "get the first subfolder in the zip file" a fallback which then supports ELN files implicitly. Make sure it works with the test from above.
- [x] ZipStream: Do the same for the reader.ZipStreamStrategy
- [x] Ensure proper error propagation and fix issues we may detect doing so

Reading is implemented in the strategies directly, as the only difference is that they need to search in subfolders. **The FolderStrategy does not implement ELN support as it does not read zip files.**

## Support writing

- [x] Make also a test for writing
- [x] Implement ELN support for zipStrategy
- [x] Implement ELN support for zipStreamStrategy

Writers need to implement an additional interface which has a method (two, actually, for semantics) to turn a writer into ELN mode. The save method is not directly part of the strategy but of the CrateWriter. As not all writers will have this functionality, it stays a configuration in the strategy.

## Other

- [x] As I make less use of some deprected functions in the CratePreview implementations, the covarage sunk. I should make some sanity test for the time being and mark this test itself as deprecated or so.
- [ ] ~~writer.ZipStrategy and writer.ZipStreamStrategy have some very similar code. Consider making a utility class or base class.~~ Postponed. Can be done later without API change.
- [x] Rename test classes consistently (writer vs strategy)
- [x] Consider renaming the new strategy classes to contain "write"/"read", as java has no way of renaming imported classes.
- [ ] ~~Make CratePreview generic?~~ May be interesting in future, but for now I do not see a big advantage.

## Documentation

- [x] Document everything well in the implementations and in the tests. See/consider also #8 
- [x] Synchronize documentation (ensure consistency, especially regarding Zip and ZipStream reader / writers)

Notes to put into the documentation:

- [x] Reading checks the first 50 non-recursive folders. I chose not to recurse and not to check all directories in order to avoid zip bombs and similar issues. Our goal is to support ELN file format and possibly a few other similar derivations.

## Deprecations

- I'd like to move away from all the responsibilities the CratePreviews have regarding different formats. Instead, I propose an API which takes a crate and expects the result to be written somewhere. This is currently a file, but could be generic... will think about it. Anyway, the old APIs are currently marked as deprecated.

## Breaking Changes

- The Readers and writers now expose IOExceptions which must be handled.
  I want this to have into the 2.x branch and therefore not want to break anything, but it turned out that the current implementation hid and logged errors to console when writing, similar to the rest of ro-crate-java. But as not every zip file is streaming-processable without a lot of memory, we need to provide a way to say "sorry, this is not going to work out". Also, reading and writing are important, high level tasks which should be handled by a developer using it.
  
  Therefore, I consider this not a breaking change, but a fix. In practice, it likely breaks for users, but it will be easy to handle.
- The methods to write an entity are now private methods in writer strategies. This is where they logically belong to. I do not consider it a breaking change because them being public was not intended anyway and just a matter of them being in the wrong place. So I consider it a fix regarding our approach to avoid invalid usage.

## Amount of main code

### Before

```
> tokei src/main
===============================================================================
 Language            Files        Lines         Code     Comments       Blanks
===============================================================================
 FreeMarker              1          201          174            0           27
 Java                   65         6436         4070         1533          833
 JSON                    4         2736         2735            0            1
===============================================================================
 Total                  70         9373         6979         1533          861
===============================================================================
```

### After / Current

```
> tokei src/main
===============================================================================
 Language            Files        Lines         Code     Comments       Blanks
===============================================================================
 FreeMarker              1          201          174            0           27
 Java                   67         6689         4153         1682          854
 JSON                    4         2736         2735            0            1
===============================================================================
 Total                  72         9626         7062         1682          882
===============================================================================
```