### PR TITLE
265 store provenance in crates about the tool which created it

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,6 +10,6 @@ authors:
   given-names: "Sabrine"
   orcid: "https://orcid.org/0000-0002-4480-6116"
 title: "ro-crate-java"
-version: 1.0.3
+version: 2.1.0-rc3
 date-released: 2022-07-19
 url: "https://github.com/kit-data-manager/ro-crate-java"

--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,22 @@ configurations {
     performanceTestImplementation.extendsFrom implementation
 }
 
+// Task for creating a resource file with the version info
+tasks.register("generateVersionProps", WriteProperties) { t ->
+    def generatedResourcesDir = project.layout.buildDirectory.dir(["resources", "main"].join(File.separator))
+    def outputFile = generatedResourcesDir.map { it.file("version.properties") }
+
+    t.destinationFile = outputFile.get().asFile
+    t.property("version", version)
+}
+
+tasks.register("generateVersionPropsTest", WriteProperties) { t ->
+    def generatedResourcesDir = project.layout.buildDirectory.dir(["resources", "test"].join(File.separator))
+    def outputFile = generatedResourcesDir.map { it.file("version.properties") }
+
+    t.destinationFile = outputFile.get().asFile
+    t.property("version", version)
+}
 
 tasks.register('performanceContextEntitiesBenchmark', JavaExec) {
     description = "Run the context entities benchmarks."
@@ -154,8 +170,13 @@ tasks.register('performanceReadWriteMultipleCratesBenchmark', JavaExec) {
     mainClass = 'edu.kit.datamanager.ro_crate.multiplecrates.MultipleCratesWriteAndRead'
 }
 
+compileJava {
+    dependsOn generateVersionProps
+}
+
 test {
     useJUnitPlatform()
+    dependsOn generateVersionPropsTest
     finalizedBy jacocoTestReport
 }
 

--- a/src/main/java/edu/kit/datamanager/ro_crate/Crate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/Crate.java
@@ -23,6 +23,28 @@ import edu.kit.datamanager.ro_crate.special.CrateVersion;
 public interface Crate {
 
   /**
+   * Mark the crate as imported, i.e. it has been read from a file
+   * or is for other reasons not considered a new crate.
+   * <p>
+   * This is useful mostly for readers to indicate this in case
+   * the crate may not have any provenance information yet and
+   * should still be recognized as an imported crate.
+   *
+   * @return this crate, for convenience.
+   */
+  Crate markAsImported();
+
+  /**
+   * Check if the crate is marked as imported.
+   * <p>
+   * If true, it indicates that the crate has been read from a file
+   * or is for other reasons not considered a new crate.
+   *
+   * @return true if the crate is marked as imported, false otherwise.
+   */
+  boolean isImported();
+
+  /**
    * Read version from the crate descriptor and return it as a class
    * representation.
    * <p>

--- a/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/RoCrate.java
@@ -50,6 +50,24 @@ public class RoCrate implements Crate {
 
     protected Collection<File> untrackedFiles;
 
+    /**
+     * Indicates whether this crate has been imported from an external source.
+     * This is used to determine if ro-crate-java should add a CreateAction
+     * or an UpdateAction in the provenance on export.
+     */
+    protected boolean isImported = false;
+
+    @Override
+    public RoCrate markAsImported() {
+        this.isImported = true;
+        return this;
+    }
+
+    @Override
+    public boolean isImported() {
+        return this.isImported;
+    }
+
     @Override
     public CratePreview getPreview() {
         return this.roCratePreview;

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
@@ -120,11 +120,9 @@ public class AbstractEntity {
      * @return the value of the property as a String or null if not found.
      */
     public String getIdProperty(String propertyKey) {
-        JsonNode node = this.properties.get(propertyKey);
-        if (node != null) {
-            return node.path("@id").asText(null);
-        }
-        return null;
+        return Optional.ofNullable(this.properties.get(propertyKey))
+                .map(jsonNode -> jsonNode.path("@id").asText(null))
+                .orElse(null);
     }
 
     @JsonIgnore

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
@@ -254,9 +254,7 @@ public class AbstractEntity {
     public void addIdProperty(String name, String id) {
         if (id == null || id.isBlank()) { return; }
         mergeIdIntoValue(id, this.properties.get(name))
-                .ifPresent(newValue -> {
-                    this.properties.set(name, newValue);
-                });
+                .ifPresent(newValue -> this.properties.set(name, newValue));
         this.linkedTo.add(id);
         this.notifyObservers();
     }
@@ -369,7 +367,7 @@ public class AbstractEntity {
     /**
      * Adds a property with date time format. The property should match the ISO 8601
      * date format.
-     * 
+     * <p>
      * Same as {@link #addProperty(String, String)} but with internal check.
      *
      * @param key   key of the property (e.g. datePublished)
@@ -424,7 +422,7 @@ public class AbstractEntity {
                 if (IdentifierUtils.isValidUri(id)) {
                     this.id = id;
                 } else {
-                    this.id = IdentifierUtils.encode(id).get();
+                    this.id = IdentifierUtils.encode(id).orElse(this.id);
                 }
             }
             return self();
@@ -461,7 +459,7 @@ public class AbstractEntity {
         /**
          * Adds a property with date time format. The property should match the ISO 8601
          * date format.
-         * 
+         * <p>
          * Same as {@link #addProperty(String, String)} but with internal check.
          *
          * @param key   key of the property (e.g. datePublished)
@@ -521,7 +519,7 @@ public class AbstractEntity {
         /**
          * ID properties are often used when referencing other entities within
          * the ROCrate. This method adds automatically such one.
-         * 
+         * <p>
          * Instead of {@code "name": "id" }
          * this will add {@code "name" : {"@id": "id"} }
          * 

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/AbstractEntity.java
@@ -112,6 +112,21 @@ public class AbstractEntity {
         return this.properties.get(propertyKey);
     }
 
+    /**
+     * Returns the value of the property with the given key as a String.
+     * If the property is not found, it returns null.
+     *
+     * @param propertyKey the key of the property.
+     * @return the value of the property as a String or null if not found.
+     */
+    public String getIdProperty(String propertyKey) {
+        JsonNode node = this.properties.get(propertyKey);
+        if (node != null) {
+            return node.path("@id").asText(null);
+        }
+        return null;
+    }
+
     @JsonIgnore
     public String getId() {
         JsonNode id = this.properties.get("@id");

--- a/src/main/java/edu/kit/datamanager/ro_crate/preview/CratePreview.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/preview/CratePreview.java
@@ -41,7 +41,7 @@ public interface CratePreview {
         // (including preview)
         new CrateWriter<>(new WriteFolderStrategy().disablePreview())
                 // We assume the caller (e.g. a writer) already stored the provenance.
-                .withAutomaticProvenance(false)
+                .withAutomaticProvenance(null)
                 .save(crate, targetDir.getAbsolutePath());
         this.saveAllToFolder(targetDir);
         try (var stream = Files.list(targetDir.toPath())) {

--- a/src/main/java/edu/kit/datamanager/ro_crate/preview/CratePreview.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/preview/CratePreview.java
@@ -40,6 +40,8 @@ public interface CratePreview {
         // as this is usually called in the process of writing a crate
         // (including preview)
         new CrateWriter<>(new WriteFolderStrategy().disablePreview())
+                // We assume the caller (e.g. a writer) already stored the provenance.
+                .withAutomaticProvenance(false)
                 .save(crate, targetDir.getAbsolutePath());
         this.saveAllToFolder(targetDir);
         try (var stream = Files.list(targetDir.toPath())) {

--- a/src/main/java/edu/kit/datamanager/ro_crate/reader/CrateReader.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/reader/CrateReader.java
@@ -97,7 +97,7 @@ public class CrateReader<T> {
         usedFiles.add(files.toPath().resolve(FILE_METADATA_JSON).toFile().getPath());
         usedFiles.add(files.toPath().resolve(FILE_PREVIEW_HTML).toFile().getPath());
         usedFiles.add(files.toPath().resolve(FILE_PREVIEW_FILES).toFile().getPath());
-        return rebuildCrate(metadataJson, files, usedFiles);
+        return rebuildCrate(metadataJson, files, usedFiles).markAsImported();
     }
 
     private RoCrate rebuildCrate(ObjectNode metadataJson, File files, HashSet<String> usedFiles) {

--- a/src/main/java/edu/kit/datamanager/ro_crate/util/ClasspathPropertiesVersionProvider.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/util/ClasspathPropertiesVersionProvider.java
@@ -1,0 +1,48 @@
+package edu.kit.datamanager.ro_crate.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Properties;
+
+public class ClasspathPropertiesVersionProvider implements VersionProvider {
+    private static final String PROPERTIES_FILE = "ro-crate-java.properties";
+    private static final String VERSION_KEY = "version";
+
+    /**
+     * Cached version to avoid repeated file/resource reads.
+     */
+    private String cachedVersion = null;
+
+    /**
+     * Constructs a ClasspathPropertiesVersionProvider that reads the version from a properties file in the classpath.
+     */
+    public ClasspathPropertiesVersionProvider() {
+        this.cachedVersion = getVersion();
+    }
+
+    @Override
+    public String getVersion() {
+        if (cachedVersion != null) {
+            return cachedVersion;
+        }
+
+        URL resource = this.getClass().getResource("/version.properties");
+        if (resource == null) {
+            throw new IllegalStateException(
+                    "version.properties not found in classpath. This indicates a build configuration issue.");
+        }
+
+        try (InputStream input = resource.openStream()) {
+            Properties properties = new Properties();
+            properties.load(input);
+            String version = properties.getProperty("version");
+            if (version == null || version.trim().isEmpty()) {
+                throw new IllegalStateException("No version property found in version.properties");
+            }
+            return version.trim();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read version from properties file", e);
+        }
+    }
+}

--- a/src/main/java/edu/kit/datamanager/ro_crate/util/ClasspathPropertiesVersionProvider.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/util/ClasspathPropertiesVersionProvider.java
@@ -28,18 +28,13 @@ public class ClasspathPropertiesVersionProvider implements VersionProvider {
         }
 
         URL resource = this.getClass().getResource("/version.properties");
-        if (resource == null) {
-            throw new IllegalStateException(
-                    "version.properties not found in classpath. This indicates a build configuration issue.");
-        }
+        assert resource != null : "version.properties not found in classpath";
 
         try (InputStream input = resource.openStream()) {
             Properties properties = new Properties();
             properties.load(input);
             String version = properties.getProperty("version");
-            if (version == null || version.trim().isEmpty()) {
-                throw new IllegalStateException("No version property found in version.properties");
-            }
+            assert version != null : "Version property not found in version.properties";
             return version.trim();
         } catch (IOException e) {
             throw new IllegalStateException("Failed to read version from properties file", e);

--- a/src/main/java/edu/kit/datamanager/ro_crate/util/ClasspathPropertiesVersionProvider.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/util/ClasspathPropertiesVersionProvider.java
@@ -6,8 +6,7 @@ import java.net.URL;
 import java.util.Properties;
 
 public class ClasspathPropertiesVersionProvider implements VersionProvider {
-    private static final String PROPERTIES_FILE = "ro-crate-java.properties";
-    private static final String VERSION_KEY = "version";
+    public static final String VERSION_PROPERTIES = "version.properties";
 
     /**
      * Cached version to avoid repeated file/resource reads.
@@ -27,14 +26,14 @@ public class ClasspathPropertiesVersionProvider implements VersionProvider {
             return cachedVersion;
         }
 
-        URL resource = this.getClass().getResource("/version.properties");
-        assert resource != null : "version.properties not found in classpath";
+        URL resource = this.getClass().getResource("/" + VERSION_PROPERTIES);
+        assert resource != null : VERSION_PROPERTIES + " not found in classpath";
 
         try (InputStream input = resource.openStream()) {
             Properties properties = new Properties();
             properties.load(input);
             String version = properties.getProperty("version");
-            assert version != null : "Version property not found in version.properties";
+            assert version != null : "Version property not found in " + VERSION_PROPERTIES;
             return version.trim();
         } catch (IOException e) {
             throw new IllegalStateException("Failed to read version from properties file", e);

--- a/src/main/java/edu/kit/datamanager/ro_crate/util/Graph.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/util/Graph.java
@@ -11,6 +11,11 @@ import java.util.stream.StreamSupport;
  * {@see JsonUtilFunctions}.
  */
 public class Graph {
+
+    private Graph() {
+        // Private constructor to prevent instantiation
+    }
+
     /**
      * Finds an entity in the graph by its ID.
      *

--- a/src/main/java/edu/kit/datamanager/ro_crate/util/Graph.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/util/Graph.java
@@ -1,0 +1,56 @@
+package edu.kit.datamanager.ro_crate.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.stream.StreamSupport;
+
+/**
+ * Utility class for handling operations on RO-Crate graphs.
+ * Provides methods to find entities by ID or type within a graph.
+ * <p>
+ * {@see JsonUtilFunctions}.
+ */
+public class Graph {
+    /**
+     * Finds an entity in the graph by its ID.
+     *
+     * @param graph The JSON node representing the graph.
+     * @param id    The ID of the entity to find.
+     * @return The entity as a JsonNode if found, null otherwise.
+     */
+    public static JsonNode findEntityById(JsonNode graph, String id) {
+        for (JsonNode entity : graph) {
+            if (entity.has("@id") && entity.get("@id").asText().equals(id)) {
+                return entity;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Finds an entity in the graph by its type.
+     *
+     * @param graph The JSON node representing the graph.
+     * @param type  The type of the entity to find.
+     * @return The entity as a JsonNode if found, null otherwise.
+     */
+    public static JsonNode findEntityByType(JsonNode graph, String type) {
+        return StreamSupport.stream(graph.spliterator(), false)
+                .filter(entity -> entity.path("@type").asText().equals(type))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Finds all entities in the graph by their type.
+     *
+     * @param graph The JSON node representing the graph.
+     * @param type  The type of the entities to find.
+     * @return An array of JsonNode containing all entities of the specified type.
+     */
+    public static JsonNode[] findEntitiesByType(JsonNode graph, String type) {
+        return StreamSupport.stream(graph.spliterator(), false)
+                .filter(entity -> entity.path("@type").asText().equals(type))
+                .toArray(JsonNode[]::new);
+    }
+}

--- a/src/main/java/edu/kit/datamanager/ro_crate/util/VersionProvider.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/util/VersionProvider.java
@@ -1,0 +1,10 @@
+package edu.kit.datamanager.ro_crate.util;
+
+public interface VersionProvider {
+    /**
+     * Returns the version of the ro-crate-java library.
+     *
+     * @return The version string.
+     */
+    String getVersion();
+}

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/CrateWriter.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/CrateWriter.java
@@ -15,14 +15,21 @@ import java.io.IOException;
 public class CrateWriter<DESTINATION_TYPE> {
 
     private final GenericWriterStrategy<DESTINATION_TYPE> strategy;
-    protected boolean automaticProvenance = true;
+    protected ProvenanceManager provenanceManager = new ProvenanceManager();
 
     public CrateWriter(GenericWriterStrategy<DESTINATION_TYPE> strategy) {
         this.strategy = strategy;
     }
 
-    public CrateWriter<DESTINATION_TYPE> withAutomaticProvenance(boolean automaticProvenance) {
-        this.automaticProvenance = automaticProvenance;
+    /**
+     * Sets the ProvenanceManager to be used for automatic provenance information
+     * generation when saving the crate.
+     *
+     * @param provenanceManager the ProvenanceManager to use. Using null will disable provenance management.
+     * @return this CrateWriter instance for method chaining.
+     */
+    public CrateWriter<DESTINATION_TYPE> withAutomaticProvenance(ProvenanceManager provenanceManager) {
+        this.provenanceManager = provenanceManager;
         return this;
     }
 
@@ -35,7 +42,7 @@ public class CrateWriter<DESTINATION_TYPE> {
     public void save(Crate crate, DESTINATION_TYPE destination) throws IOException {
         Validator defaultValidation = new Validator(new JsonSchemaValidation());
         defaultValidation.validate(crate);
-        if (automaticProvenance) {
+        if (this.provenanceManager != null) {
             new ProvenanceManager().addProvenanceInformation(crate);
         }
         this.strategy.save(crate, destination);

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/CrateWriter.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/CrateWriter.java
@@ -17,6 +17,11 @@ public class CrateWriter<DESTINATION_TYPE> {
     private final GenericWriterStrategy<DESTINATION_TYPE> strategy;
     protected ProvenanceManager provenanceManager = new ProvenanceManager();
 
+    /**
+     * Constructs a CrateWriter with a specified strategy for writing crates.
+     *
+     * @param strategy the strategy to use for writing crates.
+     */
     public CrateWriter(GenericWriterStrategy<DESTINATION_TYPE> strategy) {
         this.strategy = strategy;
     }

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/CrateWriter.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/CrateWriter.java
@@ -15,9 +15,15 @@ import java.io.IOException;
 public class CrateWriter<DESTINATION_TYPE> {
 
     private final GenericWriterStrategy<DESTINATION_TYPE> strategy;
+    protected boolean automaticProvenance = true;
 
     public CrateWriter(GenericWriterStrategy<DESTINATION_TYPE> strategy) {
         this.strategy = strategy;
+    }
+
+    public CrateWriter<DESTINATION_TYPE> withAutomaticProvenance(boolean automaticProvenance) {
+        this.automaticProvenance = automaticProvenance;
+        return this;
     }
 
     /**
@@ -29,6 +35,9 @@ public class CrateWriter<DESTINATION_TYPE> {
     public void save(Crate crate, DESTINATION_TYPE destination) throws IOException {
         Validator defaultValidation = new Validator(new JsonSchemaValidation());
         defaultValidation.validate(crate);
+        if (automaticProvenance) {
+            new ProvenanceManager().addProvenanceInformation(crate);
+        }
         this.strategy.save(crate, destination);
     }
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManager.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManager.java
@@ -7,6 +7,8 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
 
+import static edu.kit.datamanager.ro_crate.entities.contextual.ContextualEntity.ContextualEntityBuilder;
+
 /**
  * Manages provenance information for RO-Crates.
  * Handles the creation and updating of ro-crate-java entity and its actions.
@@ -25,13 +27,13 @@ class ProvenanceManager {
         // Create or update ro-crate-java entity
         ContextualEntity roCrateJavaEntity = buildRoCrateJavaEntity(crate, actionId, isFirstWrite);
 
-        // Add entities to crate in correct order (referenced entity first)
+        // Add entities to crate
         crate.addContextualEntity(roCrateJavaEntity);
         crate.addContextualEntity(actionEntity);
     }
 
     private ContextualEntity createActionEntity(String actionId, boolean isFirstWrite) {
-        return new ContextualEntity.ContextualEntityBuilder()
+        return new ContextualEntityBuilder()
             .setId(actionId)
             .addType(isFirstWrite ? "CreateAction" : "UpdateAction")
             .addProperty("startTime", Instant.now().toString())
@@ -39,61 +41,29 @@ class ProvenanceManager {
             .build();
     }
 
-    private ContextualEntity buildRoCrateJavaEntity(Crate crate, String newActionId, boolean isFirstWrite) {
-        ContextualEntity.ContextualEntityBuilder builder = new ContextualEntity.ContextualEntityBuilder()
-            .setId(RO_CRATE_JAVA_ID)
-            .addType("SoftwareApplication")
-            .addProperty("name", "ro-crate-java")
-            .addProperty("url", "https://github.com/kit-data-manager/ro-crate-java")
-            // TODO read software version and version from gradle (write into resources properties file when building and read it from there)
-            .addProperty("version", "1.0.0")
-            .addProperty("softwareVersion", "1.0.0")
-            .addProperty("license", "Apache-2.0")
-            .addProperty("description", "A Java library for creating and manipulating RO-Crates");
-
-        if (isFirstWrite) {
-            builder.addIdProperty("Action", newActionId);
-        } else {
-            Collection<ContextualEntity> entities = crate.getAllContextualEntities();
-            for (ContextualEntity entity : entities) {
-                if (RO_CRATE_JAVA_ID.equals(entity.getId())) {
-                    addActionToBuilder(builder, entity, newActionId);
-                    break;
-                }
-            }
-        }
-
-        return builder.build();
-    }
-
-    private void addActionToBuilder(
-            ContextualEntity.ContextualEntityBuilder builder,
-            ContextualEntity existingEntity,
-            String newActionId
+    private ContextualEntity buildRoCrateJavaEntity(
+            Crate crate,
+            String newActionId,
+            boolean isFirstWrite
     ) {
-        Object existingAction = existingEntity.getProperty("Action");
-        if (existingAction == null) {
-            builder.addIdProperty("action", newActionId);
-            return;
-        }
-
-        // When there are existing actions, we need to preserve them
-        if (existingAction instanceof Map) {
-            // Single previous action (as a Map containing @id)
-            String existingActionId = ((Map<?, ?>) existingAction).get("@id").toString();
-            builder.addIdProperty("Action", "#" + existingActionId);
-            builder.addIdProperty("Action", newActionId);
-        } else if (existingAction instanceof Collection<?> oldActions) {
-            // Multiple previous actions -> Add all existing actions
-            oldActions.stream()
-                .map(action -> ((Map<?, ?>) action).get("@id").toString())
-                .map(id -> !id.startsWith("#") ? "#" + id : id)
-                .forEach(id -> builder.addIdProperty("action", id));
-            // Add the new action
-            builder.addIdProperty("Action", newActionId);
-        } else {
-            // Unexpected format, just add the new action
-            builder.addIdProperty("Action", newActionId);
-        }
+        ContextualEntity self = crate.getAllContextualEntities().stream()
+                .filter(contextualEntity -> RO_CRATE_JAVA_ID.equals(contextualEntity.getId()))
+                .findFirst()
+                .orElseGet(() ->
+                        new ContextualEntityBuilder()
+                                .setId(RO_CRATE_JAVA_ID)
+                                .addType("SoftwareApplication")
+                                .addProperty("name", "ro-crate-java")
+                                .addProperty("url", "https://github.com/kit-data-manager/ro-crate-java")
+                                // TODO read software version and version from gradle (write into resources properties file when building and read it from there)
+                                .addProperty("version", "1.0.0")
+                                .addProperty("softwareVersion", "1.0.0")
+                                .addProperty("license", "Apache-2.0")
+                                .addProperty("description", "A Java library for creating and manipulating RO-Crates")
+                                .addIdProperty("Action", newActionId)
+                                .build()
+                );
+        self.addIdProperty("Action", newActionId);
+        return self;
     }
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManager.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManager.java
@@ -45,6 +45,7 @@ class ProvenanceManager {
             .addType("SoftwareApplication")
             .addProperty("name", "ro-crate-java")
             .addProperty("url", "https://github.com/kit-data-manager/ro-crate-java")
+            // TODO read software version and version from gradle (write into resources properties file when building and read it from there)
             .addProperty("version", "1.0.0")
             .addProperty("softwareVersion", "1.0.0")
             .addProperty("license", "Apache-2.0")

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManager.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManager.java
@@ -14,7 +14,19 @@ import static edu.kit.datamanager.ro_crate.entities.contextual.ContextualEntity.
  * Handles the creation and updating of ro-crate-java entity and its actions.
  */
 public class ProvenanceManager {
+    /**
+     * A record to hold the prefix for the ro-crate-java ID.
+     * This is used to ensure that the ID is consistent across different versions of the library.
+     * Having a type for the prefix avoids using it by accident as a full ID.
+     */
     protected record IdPrefix(String prefix) {
+        /**
+         * Constructs a String with the given suffix.
+         *
+         * @param suffix The suffix to append to the prefix.
+         * @return A String combining the prefix and suffix, separated by a hyphen.
+         *         Like this: "$prefix-$suffix".
+         */
         public String withSuffix(String suffix) {
             return prefix + "-" + suffix;
         }
@@ -25,8 +37,16 @@ public class ProvenanceManager {
         }
     }
 
+    /**
+     * The prefix for the ro-crate-java ID.
+     * This is used to identify the ro-crate-java entity in the crate.
+     */
     protected static final IdPrefix RO_CRATE_JAVA_ID_PREFIX = new IdPrefix("#ro-crate-java");
 
+    /**
+     * The VersionProvider used to retrieve the version of ro-crate-java.
+     * This allows for flexibility in how the version is determined, e.g., from a properties file.
+     */
     protected VersionProvider versionProvider;
 
     /**
@@ -45,11 +65,25 @@ public class ProvenanceManager {
         this.versionProvider = versionProvider;
     }
 
+    /**
+     * Returns the full ID for the ro-crate-java entity of this library version
+     * to be used for an entity describing it.
+     * <p>
+     * The ID is constructed using the RO_CRATE_JAVA_ID_PREFIX and the version from the VersionProvider.
+     *
+     * @return The ID for the ro-crate-java entity.
+     */
     public String getLibraryId() {
         return RO_CRATE_JAVA_ID_PREFIX.withSuffix(versionProvider.getVersion().toLowerCase());
     }
 
-    protected void addProvenanceInformation(Crate crate) {
+    /**
+     * Adds provenance information to the given crate.
+     * This includes creating or updating the ro-crate-java entity and its associated action entity.
+     *
+     * @param crate The crate to which provenance information will be added.
+     */
+    public void addProvenanceInformation(Crate crate) {
         // Determine if this is the first write
         boolean isFirstWrite = crate.getAllContextualEntities().stream().noneMatch(
                 entity -> entity.getId().startsWith(RO_CRATE_JAVA_ID_PREFIX.toString()))
@@ -58,7 +92,7 @@ public class ProvenanceManager {
         String libraryId = this.getLibraryId();
 
         // Create action entity first
-        ContextualEntity actionEntity = createActionEntity(isFirstWrite, libraryId);
+        ContextualEntity actionEntity = buildNewActionEntity(isFirstWrite, libraryId);
 
         // Create or update ro-crate-java entity
         ContextualEntity roCrateJavaEntity = buildRoCrateJavaEntity(crate, actionEntity.getId(), libraryId);
@@ -68,7 +102,7 @@ public class ProvenanceManager {
         crate.addContextualEntity(actionEntity);
     }
 
-    protected ContextualEntity createActionEntity(boolean isFirstWrite, String libraryId) {
+    protected ContextualEntity buildNewActionEntity(boolean isFirstWrite, String libraryId) {
         return new ContextualEntityBuilder()
                 .addType(isFirstWrite ? "CreateAction" : "UpdateAction")
                 .addIdProperty("result", "./")

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManager.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManager.java
@@ -16,7 +16,7 @@ class ProvenanceManager {
 
     void addProvenanceInformation(Crate crate) {
         // Determine if this is the first write
-        boolean isFirstWrite = !crate.getJsonMetadata().contains(RO_CRATE_JAVA_ID);
+        boolean isFirstWrite = !crate.getJsonMetadata().contains(RO_CRATE_JAVA_ID) && !crate.isImported();
 
         // Create action entity first
         String actionId = "#" + UUID.randomUUID();

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManager.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManager.java
@@ -14,7 +14,7 @@ import static edu.kit.datamanager.ro_crate.entities.contextual.ContextualEntity.
  * Handles the creation and updating of ro-crate-java entity and its actions.
  */
 class ProvenanceManager {
-    private record IdPrefix(String prefix) {
+    protected record IdPrefix(String prefix) {
         public String withSuffix(String suffix) {
             return prefix + "-" + suffix;
         }
@@ -25,7 +25,7 @@ class ProvenanceManager {
         }
     }
 
-    private static final IdPrefix RO_CRATE_JAVA_ID = new IdPrefix("#ro-crate-java");
+    protected static final IdPrefix RO_CRATE_JAVA_ID_PREFIX = new IdPrefix("#ro-crate-java");
 
     protected VersionProvider versionProvider;
 
@@ -46,13 +46,13 @@ class ProvenanceManager {
     }
 
     public String getLibraryId() {
-        return RO_CRATE_JAVA_ID.withSuffix(versionProvider.getVersion().toLowerCase());
+        return RO_CRATE_JAVA_ID_PREFIX.withSuffix(versionProvider.getVersion().toLowerCase());
     }
 
     void addProvenanceInformation(Crate crate) {
         // Determine if this is the first write
         boolean isFirstWrite = crate.getAllContextualEntities().stream().noneMatch(
-                entity -> entity.getId().startsWith(RO_CRATE_JAVA_ID.toString()))
+                entity -> entity.getId().startsWith(RO_CRATE_JAVA_ID_PREFIX.toString()))
                 && !crate.isImported();
 
         String libraryId = this.getLibraryId();

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManager.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManager.java
@@ -13,7 +13,7 @@ import static edu.kit.datamanager.ro_crate.entities.contextual.ContextualEntity.
  * Manages provenance information for RO-Crates.
  * Handles the creation and updating of ro-crate-java entity and its actions.
  */
-class ProvenanceManager {
+public class ProvenanceManager {
     protected record IdPrefix(String prefix) {
         public String withSuffix(String suffix) {
             return prefix + "-" + suffix;
@@ -49,7 +49,7 @@ class ProvenanceManager {
         return RO_CRATE_JAVA_ID_PREFIX.withSuffix(versionProvider.getVersion().toLowerCase());
     }
 
-    void addProvenanceInformation(Crate crate) {
+    protected void addProvenanceInformation(Crate crate) {
         // Determine if this is the first write
         boolean isFirstWrite = crate.getAllContextualEntities().stream().noneMatch(
                 entity -> entity.getId().startsWith(RO_CRATE_JAVA_ID_PREFIX.toString()))
@@ -68,7 +68,7 @@ class ProvenanceManager {
         crate.addContextualEntity(actionEntity);
     }
 
-    private ContextualEntity createActionEntity(boolean isFirstWrite, String libraryId) {
+    protected ContextualEntity createActionEntity(boolean isFirstWrite, String libraryId) {
         return new ContextualEntityBuilder()
                 .addType(isFirstWrite ? "CreateAction" : "UpdateAction")
                 .addIdProperty("result", "./")
@@ -77,7 +77,7 @@ class ProvenanceManager {
                 .build();
     }
 
-    private ContextualEntity buildRoCrateJavaEntity(
+    protected ContextualEntity buildRoCrateJavaEntity(
             Crate crate,
             String newActionId,
             String libraryId
@@ -86,19 +86,17 @@ class ProvenanceManager {
         ContextualEntity self = crate.getAllContextualEntities().stream()
                 .filter(contextualEntity -> libraryId.equals(contextualEntity.getId()))
                 .findFirst()
-                .orElseGet(() -> {
-                            return new ContextualEntityBuilder()
-                                    .setId(libraryId)
-                                    .addType("SoftwareApplication")
-                                    .addProperty("name", "ro-crate-java")
-                                    .addProperty("url", "https://github.com/kit-data-manager/ro-crate-java")
-                                    .addProperty("version", version)
-                                    .addProperty("softwareVersion", version)
-                                    .addProperty("license", "Apache-2.0")
-                                    .addProperty("description", "A Java library for creating and manipulating RO-Crates")
-                                    .addIdProperty("Action", newActionId)
-                                    .build();
-                        }
+                .orElseGet(() -> new ContextualEntityBuilder()
+                        .setId(libraryId)
+                        .addType("SoftwareApplication")
+                        .addProperty("name", "ro-crate-java")
+                        .addProperty("url", "https://github.com/kit-data-manager/ro-crate-java")
+                        .addProperty("version", version)
+                        .addProperty("softwareVersion", version)
+                        .addProperty("license", "Apache-2.0")
+                        .addProperty("description", "A Java library for creating and manipulating RO-Crates")
+                        .addIdProperty("Action", newActionId)
+                        .build()
                 );
         self.addIdProperty("Action", newActionId);
         return self;

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManager.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManager.java
@@ -70,10 +70,11 @@ class ProvenanceManager {
 
     private ContextualEntity createActionEntity(boolean isFirstWrite, String libraryId) {
         return new ContextualEntityBuilder()
-            .addType(isFirstWrite ? "CreateAction" : "UpdateAction")
-            .addProperty("startTime", Instant.now().toString())
-            .addIdProperty("agent", libraryId)
-            .build();
+                .addType(isFirstWrite ? "CreateAction" : "UpdateAction")
+                .addIdProperty("result", "./")
+                .addProperty("startTime", Instant.now().toString())
+                .addIdProperty("agent", libraryId)
+                .build();
     }
 
     private ContextualEntity buildRoCrateJavaEntity(

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManager.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManager.java
@@ -52,7 +52,7 @@ class ProvenanceManager {
             .addProperty("description", "A Java library for creating and manipulating RO-Crates");
 
         if (isFirstWrite) {
-            builder.addIdProperty("action", newActionId);
+            builder.addIdProperty("Action", newActionId);
         } else {
             Collection<ContextualEntity> entities = crate.getAllContextualEntities();
             for (ContextualEntity entity : entities) {
@@ -71,7 +71,7 @@ class ProvenanceManager {
             ContextualEntity existingEntity,
             String newActionId
     ) {
-        Object existingAction = existingEntity.getProperty("action");
+        Object existingAction = existingEntity.getProperty("Action");
         if (existingAction == null) {
             builder.addIdProperty("action", newActionId);
             return;
@@ -81,8 +81,8 @@ class ProvenanceManager {
         if (existingAction instanceof Map) {
             // Single previous action (as a Map containing @id)
             String existingActionId = ((Map<?, ?>) existingAction).get("@id").toString();
-            builder.addIdProperty("action", "#" + existingActionId);
-            builder.addIdProperty("action", newActionId);
+            builder.addIdProperty("Action", "#" + existingActionId);
+            builder.addIdProperty("Action", newActionId);
         } else if (existingAction instanceof Collection<?> oldActions) {
             // Multiple previous actions -> Add all existing actions
             oldActions.stream()
@@ -90,10 +90,10 @@ class ProvenanceManager {
                 .map(id -> !id.startsWith("#") ? "#" + id : id)
                 .forEach(id -> builder.addIdProperty("action", id));
             // Add the new action
-            builder.addIdProperty("action", newActionId);
+            builder.addIdProperty("Action", newActionId);
         } else {
             // Unexpected format, just add the new action
-            builder.addIdProperty("action", newActionId);
+            builder.addIdProperty("Action", newActionId);
         }
     }
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManager.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManager.java
@@ -73,21 +73,21 @@ class ProvenanceManager {
     }
 
     private String loadVersionFromProperties() {
-        try {
-            URL resource = this.getClass().getResource("/version.properties");
-            if (resource != null) {
-                try (InputStream input = resource.openStream()) {
-                    Properties properties = new Properties();
-                    properties.load(input);
-                    return properties.getProperty("version");
-                }
-            } else {
-                System.err.println("Properties file not found!");
-                return "unknown";
+        URL resource = this.getClass().getResource("/version.properties");
+        if (resource == null) {
+            throw new IllegalStateException("version.properties not found in classpath. This indicates a build configuration issue.");
+        }
+
+        try (InputStream input = resource.openStream()) {
+            Properties properties = new Properties();
+            properties.load(input);
+            String version = properties.getProperty("version");
+            if (version == null || version.trim().isEmpty()) {
+                throw new IllegalStateException("No version property found in version.properties");
             }
+            return version.trim();
         } catch (IOException e) {
-            System.err.println("Properties file not found!");
-            return "unknown";
+            throw new IllegalStateException("Failed to read version from properties file", e);
         }
     }
 }

--- a/src/main/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManager.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManager.java
@@ -1,0 +1,98 @@
+package edu.kit.datamanager.ro_crate.writer;
+
+import edu.kit.datamanager.ro_crate.Crate;
+import edu.kit.datamanager.ro_crate.entities.contextual.ContextualEntity;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Manages provenance information for RO-Crates.
+ * Handles the creation and updating of ro-crate-java entity and its actions.
+ */
+class ProvenanceManager {
+    private static final String RO_CRATE_JAVA_ID = "#ro-crate-java";
+
+    void addProvenanceInformation(Crate crate) {
+        // Determine if this is the first write
+        boolean isFirstWrite = !crate.getJsonMetadata().contains(RO_CRATE_JAVA_ID);
+
+        // Create action entity first
+        String actionId = "#" + UUID.randomUUID();
+        ContextualEntity actionEntity = createActionEntity(actionId, isFirstWrite);
+
+        // Create or update ro-crate-java entity
+        ContextualEntity roCrateJavaEntity = buildRoCrateJavaEntity(crate, actionId, isFirstWrite);
+
+        // Add entities to crate in correct order (referenced entity first)
+        crate.addContextualEntity(roCrateJavaEntity);
+        crate.addContextualEntity(actionEntity);
+    }
+
+    private ContextualEntity createActionEntity(String actionId, boolean isFirstWrite) {
+        return new ContextualEntity.ContextualEntityBuilder()
+            .setId(actionId)
+            .addType(isFirstWrite ? "CreateAction" : "UpdateAction")
+            .addProperty("startTime", Instant.now().toString())
+            .addIdProperty("agent", RO_CRATE_JAVA_ID)
+            .build();
+    }
+
+    private ContextualEntity buildRoCrateJavaEntity(Crate crate, String newActionId, boolean isFirstWrite) {
+        ContextualEntity.ContextualEntityBuilder builder = new ContextualEntity.ContextualEntityBuilder()
+            .setId(RO_CRATE_JAVA_ID)
+            .addType("SoftwareApplication")
+            .addProperty("name", "ro-crate-java")
+            .addProperty("url", "https://github.com/kit-data-manager/ro-crate-java")
+            .addProperty("version", "1.0.0")
+            .addProperty("softwareVersion", "1.0.0")
+            .addProperty("license", "Apache-2.0")
+            .addProperty("description", "A Java library for creating and manipulating RO-Crates");
+
+        if (isFirstWrite) {
+            builder.addIdProperty("action", newActionId);
+        } else {
+            Collection<ContextualEntity> entities = crate.getAllContextualEntities();
+            for (ContextualEntity entity : entities) {
+                if (RO_CRATE_JAVA_ID.equals(entity.getId())) {
+                    addActionToBuilder(builder, entity, newActionId);
+                    break;
+                }
+            }
+        }
+
+        return builder.build();
+    }
+
+    private void addActionToBuilder(
+            ContextualEntity.ContextualEntityBuilder builder,
+            ContextualEntity existingEntity,
+            String newActionId
+    ) {
+        Object existingAction = existingEntity.getProperty("action");
+        if (existingAction == null) {
+            builder.addIdProperty("action", newActionId);
+            return;
+        }
+
+        // When there are existing actions, we need to preserve them
+        if (existingAction instanceof Map) {
+            // Single previous action (as a Map containing @id)
+            String existingActionId = ((Map<?, ?>) existingAction).get("@id").toString();
+            builder.addIdProperty("action", "#" + existingActionId);
+            builder.addIdProperty("action", newActionId);
+        } else if (existingAction instanceof Collection<?> oldActions) {
+            // Multiple previous actions -> Add all existing actions
+            oldActions.stream()
+                .map(action -> ((Map<?, ?>) action).get("@id").toString())
+                .map(id -> !id.startsWith("#") ? "#" + id : id)
+                .forEach(id -> builder.addIdProperty("action", id));
+            // Add the new action
+            builder.addIdProperty("action", newActionId);
+        } else {
+            // Unexpected format, just add the new action
+            builder.addIdProperty("action", newActionId);
+        }
+    }
+}

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/CommonReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/CommonReaderTest.java
@@ -128,10 +128,10 @@ public interface CommonReaderTest<
             // write raw crate and imported crate to two different directories
             CrateWriter<String> writer = Writers.newFolderWriter();
             writer
-                    .withAutomaticProvenance(false)
+                    .withAutomaticProvenance(null)
                     .save(rawCrate, rawCrateTarget.toString());
             writer
-                    .withAutomaticProvenance(false)
+                    .withAutomaticProvenance(null)
                     .save(importedCrate, importedCrateTarget.toString());
         }
 

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/CommonReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/CommonReaderTest.java
@@ -127,8 +127,12 @@ public interface CommonReaderTest<
         {
             // write raw crate and imported crate to two different directories
             CrateWriter<String> writer = Writers.newFolderWriter();
-            writer.save(rawCrate, rawCrateTarget.toString());
-            writer.save(importedCrate, importedCrateTarget.toString());
+            writer
+                    .withAutomaticProvenance(false)
+                    .save(rawCrate, rawCrateTarget.toString());
+            writer
+                    .withAutomaticProvenance(false)
+                    .save(importedCrate, importedCrateTarget.toString());
         }
 
         assertTrue(HelpFunctions.compareTwoDir(rawCrateTarget.toFile(), importedCrateTarget.toFile()));

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/FolderReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/FolderReaderTest.java
@@ -22,7 +22,7 @@ class FolderReaderTest implements CommonReaderTest<String, ReadFolderStrategy>
   @Override
   public void saveCrate(Crate crate, Path target) throws IOException {
     Writers.newFolderWriter()
-            .withAutomaticProvenance(false)
+            .withAutomaticProvenance(null)
             .save(crate, target.toAbsolutePath().toString());
     assertTrue(target.toFile().isDirectory());
   }

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/FolderReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/FolderReaderTest.java
@@ -21,7 +21,9 @@ class FolderReaderTest implements CommonReaderTest<String, ReadFolderStrategy>
 {
   @Override
   public void saveCrate(Crate crate, Path target) throws IOException {
-    Writers.newFolderWriter().save(crate, target.toAbsolutePath().toString());
+    Writers.newFolderWriter()
+            .withAutomaticProvenance(false)
+            .save(crate, target.toAbsolutePath().toString());
     assertTrue(target.toFile().isDirectory());
   }
 

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipReaderTest.java
@@ -14,7 +14,9 @@ class ZipReaderTest implements
 {
     @Override
     public void saveCrate(Crate crate, Path target) throws IOException {
-        Writers.newZipPathWriter().save(crate, target.toAbsolutePath().toString());
+        Writers.newZipPathWriter()
+                .withAutomaticProvenance(false)
+                .save(crate, target.toAbsolutePath().toString());
         assertTrue(target.toFile().isFile());
     }
 

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipReaderTest.java
@@ -15,7 +15,7 @@ class ZipReaderTest implements
     @Override
     public void saveCrate(Crate crate, Path target) throws IOException {
         Writers.newZipPathWriter()
-                .withAutomaticProvenance(false)
+                .withAutomaticProvenance(null)
                 .save(crate, target.toAbsolutePath().toString());
         assertTrue(target.toFile().isFile());
     }

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipStreamReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipStreamReaderTest.java
@@ -33,7 +33,9 @@ class ZipStreamReaderTest implements
         try (
                 FileOutputStream fos = new FileOutputStream(target_file)
         ) {
-            Writers.newZipStreamWriter().save(crate, fos);
+            Writers.newZipStreamWriter()
+                    .withAutomaticProvenance(false)
+                    .save(crate, fos);
         }
         assertTrue(target_file.isFile());
     }

--- a/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipStreamReaderTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/reader/ZipStreamReaderTest.java
@@ -34,7 +34,7 @@ class ZipStreamReaderTest implements
                 FileOutputStream fos = new FileOutputStream(target_file)
         ) {
             Writers.newZipStreamWriter()
-                    .withAutomaticProvenance(false)
+                    .withAutomaticProvenance(null)
                     .save(crate, fos);
         }
         assertTrue(target_file.isFile());

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/FolderWriterTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/FolderWriterTest.java
@@ -16,7 +16,7 @@ class FolderWriterTest implements CommonWriterTest {
     @Override
     public void saveCrate(Crate crate, Path target) throws IOException {
         Writers.newFolderWriter()
-                .withAutomaticProvenance(false)
+                .withAutomaticProvenance(null)
                 .save(crate, target.toAbsolutePath().toString());
     }
 

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/FolderWriterTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/FolderWriterTest.java
@@ -16,6 +16,7 @@ class FolderWriterTest implements CommonWriterTest {
     @Override
     public void saveCrate(Crate crate, Path target) throws IOException {
         Writers.newFolderWriter()
+                .withAutomaticProvenance(false)
                 .save(crate, target.toAbsolutePath().toString());
     }
 

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManagerTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManagerTest.java
@@ -1,0 +1,9 @@
+package edu.kit.datamanager.ro_crate.writer;
+
+import static org.junit.jupiter.api.Assertions.*;
+class ProvenanceManagerTest {
+
+    private final String oldVersionId = new ProvenanceManager(() -> "1.0.0").getLibraryId();
+    private final String newVersionId = new ProvenanceManager(() -> "2.5.3").getLibraryId();
+  
+}

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManagerTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/ProvenanceManagerTest.java
@@ -1,9 +1,182 @@
 package edu.kit.datamanager.ro_crate.writer;
 
-import static org.junit.jupiter.api.Assertions.*;
-class ProvenanceManagerTest {
+import edu.kit.datamanager.ro_crate.Crate;
+import edu.kit.datamanager.ro_crate.RoCrate;
+import edu.kit.datamanager.ro_crate.entities.contextual.ContextualEntity;
+import org.junit.jupiter.api.Test;
 
-    private final String oldVersionId = new ProvenanceManager(() -> "1.0.0").getLibraryId();
-    private final String newVersionId = new ProvenanceManager(() -> "2.5.3").getLibraryId();
-  
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProvenanceManagerTest {
+    public final String OLD_VERSION = "1.0.0";
+    private final ProvenanceManager OLD_PROV_MANAGER = new ProvenanceManager(() -> OLD_VERSION);
+    private final String OLD_LIBRARY_ID = OLD_PROV_MANAGER.getLibraryId();
+
+    public final String NEW_VERSION = "2.5.3";
+    private final ProvenanceManager NEW_PROV_MANAGER = new ProvenanceManager(() -> NEW_VERSION);
+    private final String NEW_LIBRARY_ID = NEW_PROV_MANAGER.getLibraryId();
+
+    @Test
+    void should_CreateInitialEntities_WithCorrectVersion() {
+        // Given
+        Crate crate = new RoCrate.RoCrateBuilder().build();
+
+        // When
+        OLD_PROV_MANAGER.addProvenanceInformation(crate);
+
+        // Then
+        var entities = crate.getAllContextualEntities();
+        assertEquals(2, entities.size(), "Should have created two entities");
+
+        // Find ro-crate-java entity
+        var roCrateJavaEntity = entities.stream()
+                .filter(e -> e.getId().equals(OLD_LIBRARY_ID))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals(OLD_VERSION, roCrateJavaEntity.getProperty("version").asText());
+        assertEquals(OLD_VERSION, roCrateJavaEntity.getProperty("softwareVersion").asText());
+
+        // Find CreateAction and verify it points to correct version
+        var createAction = entities.stream()
+                .filter(e -> e.getTypes().contains("CreateAction"))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals(OLD_LIBRARY_ID, createAction.getIdProperty("agent"));
+    }
+
+    @Test
+    void should_CreateDifferentEntities_WhenDifferentVersionsModifyCrate() {
+        // Given
+        Crate crate = new RoCrate.RoCrateBuilder().build();
+
+        // When creating with old version
+        OLD_PROV_MANAGER.addProvenanceInformation(crate);
+
+        // And modifying with new version
+        NEW_PROV_MANAGER.addProvenanceInformation(crate);
+
+        // Then
+        var entities = crate.getAllContextualEntities();
+        assertEquals(4, entities.size(), "Should have four entities (2 ro-crate-java + CreateAction + UpdateAction)");
+
+        // Verify both version entities exist
+        var oldVersionEntity = entities.stream()
+                .filter(e -> e.getId().equals(OLD_LIBRARY_ID))
+                .findFirst()
+                .orElseThrow();
+        var newVersionEntity = entities.stream()
+                .filter(e -> e.getId().equals(NEW_LIBRARY_ID))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals(OLD_VERSION, oldVersionEntity.getProperty("version").asText());
+        assertEquals(NEW_VERSION, newVersionEntity.getProperty("version").asText());
+
+        // Verify actions point to correct versions
+        var createAction = entities.stream()
+                .filter(e -> e.getTypes().contains("CreateAction"))
+                .findFirst()
+                .orElseThrow();
+        var updateAction = entities.stream()
+                .filter(e -> e.getTypes().contains("UpdateAction"))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals(OLD_LIBRARY_ID, createAction.getIdProperty("agent"),
+                "CreateAction should point to old version");
+        assertEquals(NEW_LIBRARY_ID, updateAction.getIdProperty("agent"),
+                "UpdateAction should point to new version");
+    }
+
+    @Test
+    void should_ReuseExistingVersionEntity_WhenSameVersionModifiesCrateMultipleTimes() {
+        // Given
+        Crate crate = new RoCrate.RoCrateBuilder().build();
+
+        // When modifying multiple times with same version
+        OLD_PROV_MANAGER.addProvenanceInformation(crate);
+        OLD_PROV_MANAGER.addProvenanceInformation(crate);
+        OLD_PROV_MANAGER.addProvenanceInformation(crate);
+
+        // Then
+        var entities = crate.getAllContextualEntities();
+
+        // Should have one ro-crate-java entity and three actions
+        long roCrateJavaCount = entities.stream()
+                .filter(e -> e.getId().startsWith(ProvenanceManager.RO_CRATE_JAVA_ID_PREFIX.toString()))
+                .count();
+        assertEquals(1, roCrateJavaCount, "Should have only one ro-crate-java entity");
+
+        var actions = entities.stream()
+                .filter(e -> e.getTypes().contains("CreateAction") || e.getTypes().contains("UpdateAction"))
+                .toList();
+        assertEquals(3, actions.size(), "Should have three actions");
+
+        // All actions should point to the same version entity
+        for (ContextualEntity action : actions) {
+            assertEquals(OLD_LIBRARY_ID, action.getIdProperty("agent"),
+                    "All actions should point to the same version entity");
+        }
+    }
+
+    @Test
+    void should_PreserveVersionSpecificMetadata_WhenModifying() {
+        // Given
+        Crate crate = new RoCrate.RoCrateBuilder().build();
+
+        // When creating with old version
+        new ProvenanceManager(() -> OLD_VERSION).addProvenanceInformation(crate);
+
+        // And modifying with new version
+        new ProvenanceManager(() -> NEW_VERSION).addProvenanceInformation(crate);
+
+        // And modifying again with old version
+        new ProvenanceManager(() -> OLD_VERSION).addProvenanceInformation(crate);
+
+        // Then
+        var entities = crate.getAllContextualEntities();
+
+        // Should have exactly two ro-crate-java entities
+        var roCrateJavaEntities = entities.stream()
+                .filter(e -> e.getId().startsWith(ProvenanceManager.RO_CRATE_JAVA_ID_PREFIX.toString()))
+                .toList();
+        assertEquals(2, roCrateJavaEntities.size(), "Should have exactly two ro-crate-java entities");
+
+        // Each entity should maintain its complete metadata
+        for (ContextualEntity entity : roCrateJavaEntities) {
+            assertNotNull(entity.getProperty("name"), "Should have name");
+            assertNotNull(entity.getProperty("url"), "Should have url");
+            assertNotNull(entity.getProperty("license"), "Should have license");
+            assertEquals(entity.getProperty("version"),
+                    entity.getProperty("softwareVersion"),
+                    "version and softwareVersion should match");
+        }
+
+        // Actions should point to appropriate versions
+        var actions = entities.stream()
+                .filter(e -> e.getTypes().contains("CreateAction") || e.getTypes().contains("UpdateAction"))
+                .toList();
+        assertEquals(3, actions.size(), "Should have three actions");
+
+        // First action (CreateAction) should point to old version
+        var createAction = actions.stream()
+                .filter(e -> e.getTypes().contains("CreateAction"))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(OLD_LIBRARY_ID, createAction.getIdProperty("agent"),
+                "CreateAction should point to old version");
+
+        // Update actions should point to respective versions
+        var updateActions = actions.stream()
+                .filter(e -> e.getTypes().contains("UpdateAction"))
+                .toList();
+        assertEquals(2, updateActions.size(), "Should have two update actions");
+
+        assertTrue(updateActions.stream()
+                .map(e -> e.getIdProperty("agent"))
+                .allMatch(id -> id.equals(OLD_LIBRARY_ID) || id.equals(NEW_LIBRARY_ID)),
+                "Update actions should point to either old or new version");
+    }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateMetadataGenerationTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateMetadataGenerationTest.java
@@ -21,8 +21,6 @@ import static org.junit.jupiter.api.Assertions.*;
 class RoCrateMetadataGenerationTest {
 
     private final String currentVersionId = new ProvenanceManager().getLibraryId();
-    private final String oldVersionId = new ProvenanceManager(() -> "1.0.0").getLibraryId();
-    private final String newVersionId = new ProvenanceManager(() -> "2.5.3").getLibraryId();
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private Validator validator;

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateMetadataGenerationTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateMetadataGenerationTest.java
@@ -294,7 +294,7 @@ class RoCrateMetadataGenerationTest {
 
         // Use writer with disabled provenance (not implemented yet)
         Writers.newFolderWriter()
-                .withAutomaticProvenance(false)
+                .withAutomaticProvenance(null)
                 .save(originalCrate, outputPath.toString());
 
         // Verify the original crate has no provenance information

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateMetadataGenerationTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateMetadataGenerationTest.java
@@ -1,0 +1,52 @@
+package edu.kit.datamanager.ro_crate.writer;
+
+import edu.kit.datamanager.ro_crate.RoCrate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import static org.junit.jupiter.api.Assertions.*;
+
+class RoCrateMetadataGenerationTest {
+
+    @Test
+    void should_ContainRoCrateJavaEntities_When_WritingEmptyCrate(@TempDir Path tempDir) throws IOException {
+        // Create an empty RO-Crate
+        RoCrate crate = new RoCrate.RoCrateBuilder().build();
+
+        // Write it to a temporary directory
+        Path outputPath = tempDir.resolve("test-crate");
+        FolderWriter writer = new FolderWriter();
+        writer.write(crate, outputPath);
+
+        // Read the metadata file
+        String metadata = Files.readString(outputPath.resolve("ro-crate-metadata.json"));
+
+        // Verify ro-crate-java entity exists
+        assertTrue(metadata.contains("\"@id\": \"#ro-crate-java\""));
+        assertTrue(metadata.contains("\"@type\": \"SoftwareApplication\""));
+
+        // Verify write action exists
+        assertTrue(metadata.contains("\"@type\": \"CreateAction\""));
+        assertTrue(metadata.contains("startTime"));
+        assertTrue(metadata.contains("agent"));
+    }
+
+    @Test
+    void should_HaveRequiredPropertiesInRoCrateJavaEntity_When_WritingCrate(@TempDir Path tempDir) throws IOException {
+        RoCrate crate = new RoCrate.RoCrateBuilder().build();
+        Path outputPath = tempDir.resolve("test-crate");
+        FolderWriter writer = new FolderWriter();
+        writer.write(crate, outputPath);
+
+        String metadata = Files.readString(outputPath.resolve("ro-crate-metadata.json"));
+
+        // Test essential properties of the ro-crate-java entity
+        assertTrue(metadata.contains("\"name\": \"ro-crate-java\""));
+        assertTrue(metadata.contains("\"url\": \"https://github.com/kit-data-manager/ro-crate-java\""));
+        assertTrue(metadata.contains("\"version\""));
+    }
+}

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateMetadataGenerationTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateMetadataGenerationTest.java
@@ -175,7 +175,7 @@ class RoCrateMetadataGenerationTest {
         JsonNode createAction = findEntityByType(graph, "CreateAction");
         assertNotNull(createAction, "should have one CreateAction");
 
-        JsonNode[] createActions = findEntitiesByType(graph, "UpdateAction");
+        JsonNode[] createActions = findEntitiesByType(graph, "CreateAction");
         assertEquals(1, createActions.length, "should have exactly one CreateAction");
 
         JsonNode[] updateActions = findEntitiesByType(graph, "UpdateAction");
@@ -198,11 +198,12 @@ class RoCrateMetadataGenerationTest {
         String createTime = createAction.get("startTime").asText();
         String updateTime1 = updateActions[0].get("startTime").asText();
         String updateTime2 = updateActions[1].get("startTime").asText();
-
+        // The order of updates is not the order in the graph.
+        // But we can check that creation happened before the updates:
         assertTrue(createTime.compareTo(updateTime1) < 0,
             "First update should be after creation");
-        assertTrue(updateTime1.compareTo(updateTime2) < 0,
-            "Second update should be after first update");
+        assertTrue(createTime.compareTo(updateTime2) < 0,
+            "Second update should be after creation");
     }
 
     @Test
@@ -343,12 +344,10 @@ class RoCrateMetadataGenerationTest {
             "UpdateAction should reference ro-crate-java as agent");
 
         // Verify ro-crate-java references the action
-        assertTrue(roCrateJavaEntity.get("Action").isArray(),
-            "ro-crate-java should have an array of actions");
-        assertEquals(1, roCrateJavaEntity.get("Action").size(),
-            "should have exactly one action");
+        assertTrue(roCrateJavaEntity.get("Action").isObject(),
+            "ro-crate-java should have a single reference to an UpdateAction");
         assertEquals(updateAction.get("@id").asText(),
-            roCrateJavaEntity.get("Action").get(0).get("@id").asText(),
+            roCrateJavaEntity.get("Action").get("@id").asText(),
             "ro-crate-java should reference the UpdateAction");
     }
 

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateMetadataGenerationTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateMetadataGenerationTest.java
@@ -361,6 +361,11 @@ class RoCrateMetadataGenerationTest {
 
         Path outputPath = tempDir.resolve("test-crate");
         Writers.newFolderWriter().save(originalCrate, outputPath.toString());
+        try {
+            Thread.sleep(10);
+        } catch (InterruptedException e) {
+            // ignore
+        }
 
         // Now read and modify the crate
         RoCrate modifiedCrate = Readers.newFolderReader().readCrate(outputPath.toString());

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateMetadataGenerationTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateMetadataGenerationTest.java
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.stream.StreamSupport;
 
+import static edu.kit.datamanager.ro_crate.util.Graph.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 class RoCrateMetadataGenerationTest {
@@ -400,29 +400,5 @@ class RoCrateMetadataGenerationTest {
             "ro-crate-java should have an array of actions");
         assertEquals(2, roCrateJavaEntity.get("Action").size(),
             "should have both actions");
-    }
-
-    private JsonNode findEntityById(JsonNode graph, String id) {
-        for (JsonNode entity : graph) {
-            if (entity.has("@id") && entity.get("@id").asText().equals(id)) {
-                return entity;
-            }
-        }
-        return null;
-    }
-
-    private JsonNode findEntityByType(JsonNode graph, String type) {
-        for (JsonNode entity : graph) {
-            if (entity.has("@type") && entity.get("@type").asText().equals(type)) {
-                return entity;
-            }
-        }
-        return null;
-    }
-
-    private JsonNode[] findEntitiesByType(JsonNode graph, String type) {
-        return StreamSupport.stream(graph.spliterator(), false)
-            .filter(entity -> entity.has("@type") && entity.get("@type").asText().equals(type))
-            .toArray(JsonNode[]::new);
     }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateMetadataGenerationTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateMetadataGenerationTest.java
@@ -132,7 +132,7 @@ class RoCrateMetadataGenerationTest {
             "CreateAction's agent should reference ro-crate-java");
 
         // Test ro-crate-java -> CreateAction reference
-        JsonNode actionRef = roCrateJavaEntity.get("action");
+        JsonNode actionRef = roCrateJavaEntity.get("Action");
         assertNotNull(actionRef, "ro-crate-java should have action property");
         assertEquals(createActionEntity.get("@id").asText(), actionRef.get("@id").asText(),
             "ro-crate-java's action should reference the CreateAction");
@@ -166,9 +166,9 @@ class RoCrateMetadataGenerationTest {
         assertNotNull(roCrateJavaEntity, "ro-crate-java entity should exist");
 
         // Verify actions array exists and has three entries
-        assertTrue(roCrateJavaEntity.get("action").isArray(),
+        assertTrue(roCrateJavaEntity.get("Action").isArray(),
             "ro-crate-java should have an array of actions");
-        assertEquals(3, roCrateJavaEntity.get("action").size(),
+        assertEquals(3, roCrateJavaEntity.get("Action").size(),
             "should have three actions after three writes");
 
         // Find all action entities
@@ -343,12 +343,12 @@ class RoCrateMetadataGenerationTest {
             "UpdateAction should reference ro-crate-java as agent");
 
         // Verify ro-crate-java references the action
-        assertTrue(roCrateJavaEntity.get("action").isArray(),
+        assertTrue(roCrateJavaEntity.get("Action").isArray(),
             "ro-crate-java should have an array of actions");
-        assertEquals(1, roCrateJavaEntity.get("action").size(),
+        assertEquals(1, roCrateJavaEntity.get("Action").size(),
             "should have exactly one action");
         assertEquals(updateAction.get("@id").asText(),
-            roCrateJavaEntity.get("action").get(0).get("@id").asText(),
+            roCrateJavaEntity.get("Action").get(0).get("@id").asText(),
             "ro-crate-java should reference the UpdateAction");
     }
 
@@ -393,9 +393,9 @@ class RoCrateMetadataGenerationTest {
         // Verify ro-crate-java entity references both actions
         JsonNode roCrateJavaEntity = findEntityById(graph, "#ro-crate-java");
         //noinspection DataFlowIssue
-        assertTrue(roCrateJavaEntity.get("action").isArray(),
+        assertTrue(roCrateJavaEntity.get("Action").isArray(),
             "ro-crate-java should have an array of actions");
-        assertEquals(2, roCrateJavaEntity.get("action").size(),
+        assertEquals(2, roCrateJavaEntity.get("Action").size(),
             "should have both actions");
     }
 

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateMetadataGenerationTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateMetadataGenerationTest.java
@@ -141,7 +141,7 @@ class RoCrateMetadataGenerationTest {
     }
 
     @Test
-    void should_AccumulateActions_When_WritingMultipleTimes(@TempDir Path tempDir) throws IOException {
+    void should_AccumulateActions_When_WritingMultipleTimes(@TempDir Path tempDir) throws IOException, InterruptedException {
         // Create and write crate first time
         RoCrate crate = new RoCrate.RoCrateBuilder().build();
         validateCrate(crate);
@@ -149,11 +149,14 @@ class RoCrateMetadataGenerationTest {
         Path outputPath = tempDir.resolve("test-crate");
         Writers.newFolderWriter().save(crate, outputPath.toString());
         validateCrate(Readers.newFolderReader().readCrate(outputPath.toString()));
+        Thread.sleep(10);
 
         // Write same crate two more times to simulate updates
         Writers.newFolderWriter().save(crate, outputPath.toString());
+        Thread.sleep(10);
         Writers.newFolderWriter().save(crate, outputPath.toString());
         validateCrate(Readers.newFolderReader().readCrate(outputPath.toString()));
+        Thread.sleep(10);
 
         // Read and print metadata for debugging
         String metadata = Files.readString(outputPath.resolve("ro-crate-metadata.json"));
@@ -354,18 +357,14 @@ class RoCrateMetadataGenerationTest {
     }
 
     @Test
-    void should_PreserveExistingProvenance_When_ModifyingCrate(@TempDir Path tempDir) throws IOException {
+    void should_PreserveExistingProvenance_When_ModifyingCrate(@TempDir Path tempDir) throws IOException, InterruptedException {
         // First create a crate with normal provenance
         RoCrate originalCrate = new RoCrate.RoCrateBuilder().build();
         validateCrate(originalCrate);
 
         Path outputPath = tempDir.resolve("test-crate");
         Writers.newFolderWriter().save(originalCrate, outputPath.toString());
-        try {
-            Thread.sleep(10);
-        } catch (InterruptedException e) {
-            // ignore
-        }
+        Thread.sleep(10);
 
         // Now read and modify the crate
         RoCrate modifiedCrate = Readers.newFolderReader().readCrate(outputPath.toString());

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateMetadataGenerationTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateMetadataGenerationTest.java
@@ -3,6 +3,7 @@ package edu.kit.datamanager.ro_crate.writer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.kit.datamanager.ro_crate.RoCrate;
+import edu.kit.datamanager.ro_crate.HelpFunctions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -24,8 +25,12 @@ class RoCrateMetadataGenerationTest {
         Path outputPath = tempDir.resolve("test-crate");
         Writers.newFolderWriter().save(crate, outputPath.toString());
 
+        // Read and print metadata for debugging
+        String metadata = Files.readString(outputPath.resolve("ro-crate-metadata.json"));
+        HelpFunctions.prettyPrintJsonString(metadata);
+
         // Parse metadata file
-        JsonNode rootNode = objectMapper.readTree(outputPath.resolve("ro-crate-metadata.json").toFile());
+        JsonNode rootNode = objectMapper.readTree(metadata);
         JsonNode graph = rootNode.get("@graph");
 
         // Find ro-crate-java entity
@@ -49,8 +54,12 @@ class RoCrateMetadataGenerationTest {
         Path outputPath = tempDir.resolve("test-crate");
         Writers.newFolderWriter().save(crate, outputPath.toString());
 
+        // Read and print metadata for debugging
+        String metadata = Files.readString(outputPath.resolve("ro-crate-metadata.json"));
+        HelpFunctions.prettyPrintJsonString(metadata);
+
         // Parse metadata file
-        JsonNode rootNode = objectMapper.readTree(outputPath.resolve("ro-crate-metadata.json").toFile());
+        JsonNode rootNode = objectMapper.readTree(metadata);
         JsonNode roCrateJavaEntity = findEntityById(rootNode.get("@graph"), "#ro-crate-java");
 
         assertNotNull(roCrateJavaEntity, "ro-crate-java entity should exist");
@@ -70,8 +79,12 @@ class RoCrateMetadataGenerationTest {
         Path outputPath = tempDir.resolve("test-crate");
         Writers.newFolderWriter().save(crate, outputPath.toString());
 
+        // Read and print metadata for debugging
+        String metadata = Files.readString(outputPath.resolve("ro-crate-metadata.json"));
+        HelpFunctions.prettyPrintJsonString(metadata);
+
         // Parse metadata file
-        JsonNode rootNode = objectMapper.readTree(outputPath.resolve("ro-crate-metadata.json").toFile());
+        JsonNode rootNode = objectMapper.readTree(metadata);
         JsonNode graph = rootNode.get("@graph");
 
         // Get both entities
@@ -105,8 +118,12 @@ class RoCrateMetadataGenerationTest {
         Writers.newFolderWriter().save(crate, outputPath.toString());
         Writers.newFolderWriter().save(crate, outputPath.toString());
 
-        // Parse final metadata file
-        JsonNode rootNode = objectMapper.readTree(outputPath.resolve("ro-crate-metadata.json").toFile());
+        // Read and print metadata for debugging
+        String metadata = Files.readString(outputPath.resolve("ro-crate-metadata.json"));
+        HelpFunctions.prettyPrintJsonString(metadata);
+
+        // Parse metadata file
+        JsonNode rootNode = objectMapper.readTree(metadata);
         JsonNode graph = rootNode.get("@graph");
 
         // Get ro-crate-java entity

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateMetadataGenerationTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateMetadataGenerationTest.java
@@ -20,6 +20,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class RoCrateMetadataGenerationTest {
 
+    private final String currentVersionId = new ProvenanceManager().getLibraryId();
+    private final String oldVersionId = new ProvenanceManager(() -> "1.0.0").getLibraryId();
+    private final String newVersionId = new ProvenanceManager(() -> "2.5.3").getLibraryId();
+
     private final ObjectMapper objectMapper = new ObjectMapper();
     private Validator validator;
 
@@ -55,7 +59,7 @@ class RoCrateMetadataGenerationTest {
         JsonNode graph = rootNode.get("@graph");
 
         // Find ro-crate-java entity
-        JsonNode roCrateJavaEntity = findEntityById(graph, "#ro-crate-java");
+        JsonNode roCrateJavaEntity = findEntityById(graph, this.currentVersionId);
         assertNotNull(roCrateJavaEntity, "ro-crate-java entity should exist");
         assertEquals("SoftwareApplication", roCrateJavaEntity.get("@type").asText(),
             "ro-crate-java should be of type SoftwareApplication");
@@ -64,7 +68,7 @@ class RoCrateMetadataGenerationTest {
         JsonNode createActionEntity = findEntityByType(graph, "CreateAction");
         assertNotNull(createActionEntity, "CreateAction entity should exist");
         assertNotNull(createActionEntity.get("startTime"), "CreateAction should have startTime");
-        assertEquals("#ro-crate-java", createActionEntity.get("agent").get("@id").asText(),
+        assertEquals(this.currentVersionId, createActionEntity.get("agent").get("@id").asText(),
             "CreateAction should reference ro-crate-java as agent");
     }
 
@@ -86,7 +90,7 @@ class RoCrateMetadataGenerationTest {
 
         // Parse metadata file
         JsonNode rootNode = objectMapper.readTree(metadata);
-        JsonNode roCrateJavaEntity = findEntityById(rootNode.get("@graph"), "#ro-crate-java");
+        JsonNode roCrateJavaEntity = findEntityById(rootNode.get("@graph"), this.currentVersionId);
 
         assertNotNull(roCrateJavaEntity, "ro-crate-java entity should exist");
         assertEquals("ro-crate-java", roCrateJavaEntity.get("name").asText(),
@@ -119,7 +123,7 @@ class RoCrateMetadataGenerationTest {
         JsonNode graph = rootNode.get("@graph");
 
         // Get both entities
-        JsonNode roCrateJavaEntity = findEntityById(graph, "#ro-crate-java");
+        JsonNode roCrateJavaEntity = findEntityById(graph, this.currentVersionId);
         JsonNode createActionEntity = findEntityByType(graph, "CreateAction");
 
         assertNotNull(roCrateJavaEntity, "ro-crate-java entity should exist");
@@ -128,7 +132,7 @@ class RoCrateMetadataGenerationTest {
         // Test CreateAction -> ro-crate-java reference
         JsonNode agentRef = createActionEntity.get("agent");
         assertNotNull(agentRef, "CreateAction should have agent property");
-        assertEquals("#ro-crate-java", agentRef.get("@id").asText(),
+        assertEquals(this.currentVersionId, agentRef.get("@id").asText(),
             "CreateAction's agent should reference ro-crate-java");
 
         // Test ro-crate-java -> CreateAction reference
@@ -162,7 +166,7 @@ class RoCrateMetadataGenerationTest {
         JsonNode graph = rootNode.get("@graph");
 
         // Get ro-crate-java entity
-        JsonNode roCrateJavaEntity = findEntityById(graph, "#ro-crate-java");
+        JsonNode roCrateJavaEntity = findEntityById(graph, this.currentVersionId);
         assertNotNull(roCrateJavaEntity, "ro-crate-java entity should exist");
 
         // Verify actions array exists and has three entries
@@ -183,14 +187,14 @@ class RoCrateMetadataGenerationTest {
 
         // Verify CreateAction properties
         assertNotNull(createAction.get("startTime"), "CreateAction should have startTime");
-        assertEquals("#ro-crate-java", createAction.get("agent").get("@id").asText(),
+        assertEquals(this.currentVersionId, createAction.get("agent").get("@id").asText(),
             "CreateAction should reference ro-crate-java as agent");
 
         // Verify UpdateAction properties
         for (JsonNode updateAction : updateActions) {
             assertNotNull(updateAction.get("startTime"),
                 "UpdateAction should have startTime");
-            assertEquals("#ro-crate-java", updateAction.get("agent").get("@id").asText(),
+            assertEquals(this.currentVersionId, updateAction.get("agent").get("@id").asText(),
                 "UpdateAction should reference ro-crate-java as agent");
         }
 
@@ -222,7 +226,7 @@ class RoCrateMetadataGenerationTest {
 
         // Parse metadata file
         JsonNode rootNode = objectMapper.readTree(metadata);
-        JsonNode roCrateJavaEntity = findEntityById(rootNode.get("@graph"), "#ro-crate-java");
+        JsonNode roCrateJavaEntity = findEntityById(rootNode.get("@graph"), this.currentVersionId);
 
         // Version format validation
         @SuppressWarnings("DataFlowIssue")
@@ -256,7 +260,7 @@ class RoCrateMetadataGenerationTest {
 
         // Parse metadata file
         JsonNode rootNode = objectMapper.readTree(metadata);
-        JsonNode roCrateJavaEntity = findEntityById(rootNode.get("@graph"), "#ro-crate-java");
+        JsonNode roCrateJavaEntity = findEntityById(rootNode.get("@graph"), this.currentVersionId);
 
         // Required properties with specific values
         assertEquals("ro-crate-java", roCrateJavaEntity.get("name").asText(),
@@ -301,7 +305,7 @@ class RoCrateMetadataGenerationTest {
 
         JsonNode originalRoot = objectMapper.readTree(originalMetadata);
         JsonNode originalGraph = originalRoot.get("@graph");
-        assertNull(findEntityById(originalGraph, "#ro-crate-java"),
+        assertNull(findEntityById(originalGraph, this.currentVersionId),
             "Original crate should not have ro-crate-java entity");
         assertNull(findEntityByType(originalGraph, "CreateAction"),
             "Original crate should not have CreateAction");
@@ -326,7 +330,7 @@ class RoCrateMetadataGenerationTest {
         JsonNode modifiedGraph = modifiedRoot.get("@graph");
 
         // Verify ro-crate-java entity was added
-        JsonNode roCrateJavaEntity = findEntityById(modifiedGraph, "#ro-crate-java");
+        JsonNode roCrateJavaEntity = findEntityById(modifiedGraph, this.currentVersionId);
         assertNotNull(roCrateJavaEntity, "ro-crate-java entity should be added");
 
         // Should only have UpdateAction, no CreateAction
@@ -339,7 +343,7 @@ class RoCrateMetadataGenerationTest {
         // Verify update action properties
         assertNotNull(updateAction.get("startTime"),
             "UpdateAction should have startTime");
-        assertEquals("#ro-crate-java",
+        assertEquals(this.currentVersionId,
             updateAction.get("agent").get("@id").asText(),
             "UpdateAction should reference ro-crate-java as agent");
 
@@ -390,7 +394,7 @@ class RoCrateMetadataGenerationTest {
             "Update should be after creation");
 
         // Verify ro-crate-java entity references both actions
-        JsonNode roCrateJavaEntity = findEntityById(graph, "#ro-crate-java");
+        JsonNode roCrateJavaEntity = findEntityById(graph, this.currentVersionId);
         //noinspection DataFlowIssue
         assertTrue(roCrateJavaEntity.get("Action").isArray(),
             "ro-crate-java should have an array of actions");

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateWriterSpec12Test.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateWriterSpec12Test.java
@@ -30,6 +30,7 @@ class RoCrateWriterSpec12Test {
         Path targetDir = tempDir.resolve("spec12writeUnmodified");
 
         Writers.newFolderWriter()
+                .withAutomaticProvenance(false)
                 .save(crate, targetDir.toAbsolutePath().toString());
 
         // compare directories

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateWriterSpec12Test.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/RoCrateWriterSpec12Test.java
@@ -30,7 +30,7 @@ class RoCrateWriterSpec12Test {
         Path targetDir = tempDir.resolve("spec12writeUnmodified");
 
         Writers.newFolderWriter()
-                .withAutomaticProvenance(false)
+                .withAutomaticProvenance(null)
                 .save(crate, targetDir.toAbsolutePath().toString());
 
         // compare directories

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipStreamWriterTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipStreamWriterTest.java
@@ -18,7 +18,7 @@ class ZipStreamWriterTest implements
   public void saveCrate(Crate crate, Path target) throws IOException {
     try (FileOutputStream stream = new FileOutputStream(target.toFile())) {
       Writers.newZipStreamWriter()
-              .withAutomaticProvenance(false)
+              .withAutomaticProvenance(null)
               .save(crate, stream);
     }
   }
@@ -27,7 +27,7 @@ class ZipStreamWriterTest implements
   public void saveCrateElnStyle(Crate crate, Path target) throws IOException {
     try (FileOutputStream stream = new FileOutputStream(target.toFile())) {
       new CrateWriter<>(new WriteZipStreamStrategy().usingElnStyle())
-              .withAutomaticProvenance(false)
+              .withAutomaticProvenance(null)
               .save(crate, stream);
     }
   }
@@ -36,7 +36,7 @@ class ZipStreamWriterTest implements
   public void saveCrateSubdirectoryStyle(RoCrate crate, Path target) throws IOException {
     try (FileOutputStream stream = new FileOutputStream(target.toFile())) {
       new CrateWriter<>(new WriteZipStreamStrategy().withRootSubdirectory())
-              .withAutomaticProvenance(false)
+              .withAutomaticProvenance(null)
               .save(crate, stream);
     }
   }

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipStreamWriterTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipStreamWriterTest.java
@@ -17,7 +17,9 @@ class ZipStreamWriterTest implements
   @Override
   public void saveCrate(Crate crate, Path target) throws IOException {
     try (FileOutputStream stream = new FileOutputStream(target.toFile())) {
-      Writers.newZipStreamWriter().save(crate, stream);
+      Writers.newZipStreamWriter()
+              .withAutomaticProvenance(false)
+              .save(crate, stream);
     }
   }
 
@@ -25,6 +27,7 @@ class ZipStreamWriterTest implements
   public void saveCrateElnStyle(Crate crate, Path target) throws IOException {
     try (FileOutputStream stream = new FileOutputStream(target.toFile())) {
       new CrateWriter<>(new WriteZipStreamStrategy().usingElnStyle())
+              .withAutomaticProvenance(false)
               .save(crate, stream);
     }
   }
@@ -33,6 +36,7 @@ class ZipStreamWriterTest implements
   public void saveCrateSubdirectoryStyle(RoCrate crate, Path target) throws IOException {
     try (FileOutputStream stream = new FileOutputStream(target.toFile())) {
       new CrateWriter<>(new WriteZipStreamStrategy().withRootSubdirectory())
+              .withAutomaticProvenance(false)
               .save(crate, stream);
     }
   }

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipWriterTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipWriterTest.java
@@ -13,18 +13,21 @@ class ZipWriterTest implements
     @Override
     public void saveCrate(Crate crate, Path target) throws IOException {
         Writers.newZipPathWriter()
+                .withAutomaticProvenance(false)
                 .save(crate, target.toAbsolutePath().toString());
     }
 
     @Override
     public void saveCrateElnStyle(Crate crate, Path target) throws IOException {
         new CrateWriter<>(new WriteZipStrategy().usingElnStyle())
+                .withAutomaticProvenance(false)
                 .save(crate, target.toAbsolutePath().toString());
     }
 
     @Override
     public void saveCrateSubdirectoryStyle(RoCrate crate, Path target) throws IOException {
         new CrateWriter<>(new WriteZipStrategy().withRootSubdirectory())
+                .withAutomaticProvenance(false)
                 .save(crate, target.toString());
     }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipWriterTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/writer/ZipWriterTest.java
@@ -13,21 +13,21 @@ class ZipWriterTest implements
     @Override
     public void saveCrate(Crate crate, Path target) throws IOException {
         Writers.newZipPathWriter()
-                .withAutomaticProvenance(false)
+                .withAutomaticProvenance(null)
                 .save(crate, target.toAbsolutePath().toString());
     }
 
     @Override
     public void saveCrateElnStyle(Crate crate, Path target) throws IOException {
         new CrateWriter<>(new WriteZipStrategy().usingElnStyle())
-                .withAutomaticProvenance(false)
+                .withAutomaticProvenance(null)
                 .save(crate, target.toAbsolutePath().toString());
     }
 
     @Override
     public void saveCrateSubdirectoryStyle(RoCrate crate, Path target) throws IOException {
         new CrateWriter<>(new WriteZipStrategy().withRootSubdirectory())
-                .withAutomaticProvenance(false)
+                .withAutomaticProvenance(null)
                 .save(crate, target.toString());
     }
 }


### PR DESCRIPTION
Closes #265 

todo

- [x] fix remaining tests
- [x] read version information dynamically from resources instead of hard-coding it
- [x] create/update-actions may be performed by different versions of ro-crate-java, so we need to add entities for each ro-crate-java version involved.