### PR TITLE
deps: update json schema validator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     // JSON-LD, Zenodo mapping
     implementation group: 'com.apicatalog', name: 'titanium-json-ld', version: '1.7.0'
     // metadata validation, profiles based on JSON schema
-    implementation group: "com.networknt", name: "json-schema-validator", version: "1.5.9"
+    implementation group: "com.networknt", name: "json-schema-validator", version: "2.0.1"
     implementation 'org.glassfish:jakarta.json:2.0.1'
     //JTE for template processing
     implementation('gg.jte:jte:3.2.4')

--- a/src/main/java/edu/kit/datamanager/ro_crate/entities/validation/JsonSchemaValidation.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/entities/validation/JsonSchemaValidation.java
@@ -3,15 +3,14 @@ package edu.kit.datamanager.ro_crate.entities.validation;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.networknt.schema.JsonSchema;
-import com.networknt.schema.JsonSchemaFactory;
-import com.networknt.schema.SpecVersion;
-import com.networknt.schema.ValidationMessage;
-
+import com.networknt.schema.Error;
+import com.networknt.schema.InputFormat;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaLocation;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.dialect.Dialects;
 import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
-
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.Objects;
 import java.util.Set;
 
@@ -20,27 +19,28 @@ import java.util.Set;
  */
 public class JsonSchemaValidation implements EntityValidationStrategy {
 
-  private static final URL entitySchemaDefault
-      = Objects.requireNonNull(JsonSchemaValidation.class.getClassLoader()
-      .getResource("json_schemas/entity_schema.json"));
-  private static final URL fieldSchemaDefault
-      = Objects.requireNonNull(JsonSchemaValidation.class.getClassLoader()
-      .getResource("json_schemas/entity_field_structure_schema.json"));
+  private static final String entitySchemaClasspath =
+    "classpath:json_schemas/entity_schema.json";
+  private static final String fieldSchemaClasspath =
+    "classpath:json_schemas/entity_field_structure_schema.json";
 
-  private JsonSchema entitySchema;
-  private JsonSchema entityFieldSchema;
+  private Schema entitySchema;
+  private Schema entityFieldSchema;
 
   /**
    *  Default constructor that uses the default schemas.
    */
   public JsonSchemaValidation() {
-    JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909);
-    try {
-      this.entitySchema = factory.getSchema(entitySchemaDefault.toURI());
-      this.entityFieldSchema = factory.getSchema(fieldSchemaDefault.toURI());
-    } catch (URISyntaxException e) {
-      e.printStackTrace();
-    }
+    // Use classpath: URI scheme - $ref resolution is automatic!
+    SchemaRegistry schemaRegistry = SchemaRegistry.withDialect(
+      Dialects.getDraft201909()
+    );
+    this.entitySchema = schemaRegistry.getSchema(
+      SchemaLocation.of(entitySchemaClasspath)
+    );
+    this.entityFieldSchema = schemaRegistry.getSchema(
+      SchemaLocation.of(fieldSchemaClasspath)
+    );
   }
 
   /**
@@ -50,16 +50,26 @@ public class JsonSchemaValidation implements EntityValidationStrategy {
    * @param fieldSchema schema for the field validation.
    */
   public JsonSchemaValidation(JsonNode entitySchema, JsonNode fieldSchema) {
-    JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909);
-    this.entitySchema = factory.getSchema(entitySchema);
-    this.entityFieldSchema = factory.getSchema(fieldSchema);
+    SchemaRegistry schemaRegistry = SchemaRegistry.withDialect(
+      Dialects.getDraft201909()
+    );
+    this.entitySchema = schemaRegistry.getSchema(
+      entitySchema.toString(),
+      InputFormat.JSON
+    );
+    this.entityFieldSchema = schemaRegistry.getSchema(
+      fieldSchema.toString(),
+      InputFormat.JSON
+    );
   }
 
   @Override
   public boolean validateEntity(JsonNode entity) {
-    Set<ValidationMessage> errors = this.entitySchema.validate(entity);
-    if (errors.size() != 0) {
-      System.err.println("This entity does not comply to the basic RO-Crate entity structure.");
+    java.util.List<Error> errors = this.entitySchema.validate(entity);
+    if (!errors.isEmpty()) {
+      System.err.println(
+        "This entity does not comply to the basic RO-Crate entity structure."
+      );
       errors.forEach(error -> System.err.println(error.getMessage()));
       return false;
     }
@@ -68,17 +78,23 @@ public class JsonSchemaValidation implements EntityValidationStrategy {
 
   @Override
   public boolean validateFieldOfEntity(JsonNode field) {
-    Set<ValidationMessage> errors = this.entityFieldSchema.validate(field);
+    java.util.List<Error> errors = this.entityFieldSchema.validate(field);
     if (!errors.isEmpty()) {
       ObjectMapper objectMapper = MyObjectMapper.getMapper();
       System.err.println("The property: ");
       try {
-        System.err.println(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(field));
+        System.err.println(
+          objectMapper
+            .writerWithDefaultPrettyPrinter()
+            .writeValueAsString(field)
+        );
       } catch (JsonProcessingException e) {
         e.printStackTrace();
       }
-      System.err.println("does not comply with the flattened structure"
-          + " of the RO-Crate json document.");
+      System.err.println(
+        "does not comply with the flattened structure" +
+          " of the RO-Crate json document."
+      );
       return false;
     }
     return true;

--- a/src/main/java/edu/kit/datamanager/ro_crate/validation/JsonSchemaValidation.java
+++ b/src/main/java/edu/kit/datamanager/ro_crate/validation/JsonSchemaValidation.java
@@ -2,18 +2,21 @@ package edu.kit.datamanager.ro_crate.validation;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.networknt.schema.JsonSchema;
-import com.networknt.schema.JsonSchemaFactory;
-import com.networknt.schema.SpecVersion;
-import com.networknt.schema.ValidationMessage;
-
+import com.networknt.schema.Error;
+import com.networknt.schema.InputFormat;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaLocation;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.SpecificationVersion;
+import com.networknt.schema.dialect.Dialects;
 import edu.kit.datamanager.ro_crate.Crate;
 import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
-
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.Set;
 
@@ -22,25 +25,42 @@ import java.util.Set;
  */
 public class JsonSchemaValidation implements ValidatorStrategy {
 
-  private static final String defaultSchema = "json_schemas/default.json";
-  private JsonSchema schema;
+  private static final String defaultSchemaClasspath =
+    "classpath:json_schemas/default.json";
+  private Schema schema;
 
   private void getSchema(URI schemaUri) {
-    JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909);
-    this.schema = factory.getSchema(schemaUri);
+    try {
+      // Enable fetchRemoteResources to support file:// and http:// $ref resolution
+      SchemaRegistry schemaRegistry = SchemaRegistry.withDialect(
+        Dialects.getDraft201909(),
+        builder -> builder.schemaLoader(loader -> loader.fetchRemoteResources())
+      );
+
+      // For bundled schemas, use classpath: URI
+      String location =
+        schemaUri.getScheme() == null ||
+        "classpath".equals(schemaUri.getScheme())
+          ? defaultSchemaClasspath
+          : schemaUri.toString();
+
+      this.schema = schemaRegistry.getSchema(SchemaLocation.of(location));
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to load schema: " + schemaUri, e);
+    }
   }
 
   /**
    * Default constructor for the JSON-schema validation.
    */
   public JsonSchemaValidation() {
-    try {
-      URI schemaUri = Objects.requireNonNull(
-          getClass().getClassLoader().getResource(defaultSchema)).toURI();
-      getSchema(schemaUri);
-    } catch (URISyntaxException e) {
-      e.printStackTrace();
-    }
+    // Use classpath: URI scheme - $ref resolution is automatic!
+    SchemaRegistry schemaRegistry = SchemaRegistry.withDialect(
+      Dialects.getDraft201909()
+    );
+    this.schema = schemaRegistry.getSchema(
+      SchemaLocation.of(defaultSchemaClasspath)
+    );
   }
 
   public JsonSchemaValidation(URI schemaUri) {
@@ -53,8 +73,10 @@ public class JsonSchemaValidation implements ValidatorStrategy {
   }
 
   public JsonSchemaValidation(JsonNode schema) {
-    JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909);
-    this.schema = factory.getSchema(schema);
+    SchemaRegistry schemaRegistry = SchemaRegistry.withDialect(
+      Dialects.getDraft201909()
+    );
+    this.schema = schemaRegistry.getSchema(schema.toString(), InputFormat.JSON);
   }
 
   @Override
@@ -62,13 +84,15 @@ public class JsonSchemaValidation implements ValidatorStrategy {
     ObjectMapper objectMapper = MyObjectMapper.getMapper();
     try {
       final JsonNode good = objectMapper.readTree(crate.getJsonMetadata());
-      Set<ValidationMessage> errors = this.schema.validate(good);
+      java.util.List<Error> errors = this.schema.validate(good);
       if (errors.size() == 0) {
         return true;
       } else {
-        System.err.println("This crate does not validate against the this schema."
-            + " If you haven't provided any schemas,"
-            + " then it does not validate against the default one.");
+        System.err.println(
+          "This crate does not validate against the this schema." +
+            " If you haven't provided any schemas," +
+            " then it does not validate against the default one."
+        );
         for (var e : errors) {
           System.err.println(e.getMessage());
         }

--- a/src/test/java/edu/kit/datamanager/ro_crate/crate/validation/ValidationTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/crate/validation/ValidationTest.java
@@ -1,46 +1,52 @@
 package edu.kit.datamanager.ro_crate.crate.validation;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import edu.kit.datamanager.ro_crate.Crate;
 import edu.kit.datamanager.ro_crate.RoCrate;
 import edu.kit.datamanager.ro_crate.entities.data.WorkflowEntity;
 import edu.kit.datamanager.ro_crate.objectmapper.MyObjectMapper;
 import edu.kit.datamanager.ro_crate.validation.JsonSchemaValidation;
 import edu.kit.datamanager.ro_crate.validation.Validator;
-
-import org.junit.jupiter.api.Test;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Objects;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 public class ValidationTest {
 
   @Test
   void jsonSchemaValidationTest() throws IOException, URISyntaxException {
-    Crate crate = new RoCrate.RoCrateBuilder("workflowCrate", "this is a test", "2024", "https://creativecommons.org/licenses/by-nc-sa/3.0/au/")
-        .addDataEntity(
-            new WorkflowEntity.WorkflowEntityBuilder()
-                .setId("https://www.example.com/entity")
-                .build()
-        )
-        .build();
+    Crate crate = new RoCrate.RoCrateBuilder(
+      "workflowCrate",
+      "this is a test",
+      "2024",
+      "https://creativecommons.org/licenses/by-nc-sa/3.0/au/"
+    )
+      .addDataEntity(
+        new WorkflowEntity.WorkflowEntityBuilder()
+          .setId("https://www.example.com/entity")
+          .build()
+      )
+      .build();
 
-    InputStream inputStream =
-        ValidationTest.class.getResourceAsStream("/crates/validation/workflowschema.json");
+    InputStream inputStream = ValidationTest.class.getResourceAsStream(
+      "/crates/validation/workflowschema.json"
+    );
     ObjectMapper objectMapper = MyObjectMapper.getMapper();
     JsonNode expectedJson = objectMapper.readTree(inputStream);
 
     Validator validator = new Validator(new JsonSchemaValidation(expectedJson));
     assertTrue(validator.validate(crate));
-    URL schemaUrl = Objects.requireNonNull(ValidationTest.class.getResource("/crates/validation/workflowschema.json"));
+    URL schemaUrl = Objects.requireNonNull(
+      ValidationTest.class.getResource("/crates/validation/workflowschema.json")
+    );
     String schemaPath = schemaUrl.getPath();
     // test with string file location
     validator = new Validator(new JsonSchemaValidation(schemaPath));
@@ -52,5 +58,46 @@ public class ValidationTest {
     crate.deleteEntityById("https://www.example.com/entity");
     // crate should not match this schema
     assertFalse(validator.validate(crate));
+  }
+
+  @Test
+  void customSchemaWithCrossFileRefTest()
+    throws IOException, URISyntaxException {
+    // Test that custom schemas with cross-file $ref references load correctly.
+    // If $ref resolution fails, the constructor would throw an exception.
+    URL parentSchemaUrl = Objects.requireNonNull(
+      ValidationTest.class.getResource(
+        "/json_schemas/custom-parent-schema.json"
+      )
+    );
+
+    // This constructor call will fail if $ref to custom-child-schema.json can't be resolved
+    JsonSchemaValidation schemaValidation = new JsonSchemaValidation(
+      parentSchemaUrl.toURI()
+    );
+    Validator validator = new Validator(schemaValidation);
+
+    // Create a crate - validation will run but the crate structure won't match
+    // our custom schema (which expects {"person": {"name": "..."}}).
+    // The key assertion is that schema LOADING succeeded (no exception above).
+    RoCrate crate = new RoCrate.RoCrateBuilder(
+      "Test",
+      "Desc",
+      "2024",
+      "https://creativecommons.org/licenses/by-nc-sa/3.0/au/"
+    ).build();
+
+    // Validate returns false because crate structure doesn't match custom schema,
+    // but the important thing is that validation RUNS without errors
+    boolean result = validator.validate(crate);
+
+    // We expect false because our crate doesn't have the "person" field
+    // that the custom schema requires. This proves:
+    // 1. Schema loaded successfully ($ref was resolved)
+    // 2. Validation executed against the loaded schema
+    assertFalse(
+      result,
+      "Crate should not validate against custom schema (missing 'person' field)"
+    );
   }
 }

--- a/src/test/java/edu/kit/datamanager/ro_crate/validation/ClasspathResourceLoadingTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/validation/ClasspathResourceLoadingTest.java
@@ -1,0 +1,60 @@
+package edu.kit.datamanager.ro_crate.validation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.networknt.schema.InputFormat;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaLocation;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.dialect.Dialects;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test to verify the migration document claim that
+ * "classpath resources will still be automatically loaded"
+ * when using the classpath: URI scheme.
+ */
+class ClasspathResourceLoadingTest {
+
+  /**
+   * Note: file:// URIs do NOT support automatic $ref resolution.
+   * Our implementation handles this by scanning the directory for sibling schemas.
+   */
+
+  @Test
+  void testClasspathUriSchemeRefResolution() {
+    // This test verifies if using classpath: URI scheme enables
+    // automatic $ref resolution as the migration document suggests
+
+    // Create SchemaRegistry WITHOUT registering any schemas
+    SchemaRegistry schemaRegistry = SchemaRegistry.withDialect(
+      Dialects.getDraft201909()
+      // NOTE: We're NOT calling .schemas() to register anything
+    );
+
+    // Try to load schema using classpath: URI scheme
+    assertDoesNotThrow(() -> {
+      Schema schema = schemaRegistry.getSchema(
+        SchemaLocation.of(
+          "classpath:json_schemas/classpath-ref-test-parent.json"
+        )
+      );
+
+      // If we got here, the schema loaded
+      // Now try to validate data that requires the child schema via $ref
+      var validData = "{\"person\": {\"name\": \"John\"}}";
+      var errors = schema.validate(validData, InputFormat.JSON);
+
+      // Should have no errors for valid data if $ref was resolved
+      assertTrue(
+        errors.isEmpty(),
+        "Valid data should pass validation. Errors: " + errors
+      );
+    }, "Schema with $ref should work using classpath: URI scheme without manual registration");
+  }
+}

--- a/src/test/java/edu/kit/datamanager/ro_crate/validation/ComprehensiveRefResolutionTest.java
+++ b/src/test/java/edu/kit/datamanager/ro_crate/validation/ComprehensiveRefResolutionTest.java
@@ -1,0 +1,346 @@
+package edu.kit.datamanager.ro_crate.validation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.networknt.schema.Error;
+import com.networknt.schema.InputFormat;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaLocation;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.dialect.Dialects;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Comprehensive tests for $ref resolution in json-schema-validator 2.x
+ * Tests various scenarios: siblings, nested paths, absolute paths, classpath, file://
+ */
+class ComprehensiveRefResolutionTest {
+
+  /**
+   * Test 1: Classpath schemas with relative $ref to sibling
+   * This SHOULD work - classpath: URIs support automatic $ref resolution
+   */
+  @Test
+  void testClasspathSiblingRef() throws Exception {
+    SchemaRegistry schemaRegistry = SchemaRegistry.withDialect(
+      Dialects.getDraft201909()
+    );
+
+    Schema schema = schemaRegistry.getSchema(
+      SchemaLocation.of("classpath:json_schemas/custom-parent-schema.json")
+    );
+
+    List<Error> errors = schema.validate(
+      "{\"person\": {\"name\": \"John\"}}",
+      InputFormat.JSON
+    );
+    assertTrue(
+      errors.isEmpty(),
+      "Should validate with valid data. Errors: " + errors
+    );
+
+    List<Error> invalidErrors = schema.validate(
+      "{\"person\": {}}",
+      InputFormat.JSON
+    );
+    assertFalse(
+      invalidErrors.isEmpty(),
+      "Should fail validation without required name"
+    );
+  }
+
+  /**
+   * Test 2: File-based schemas with relative $ref to sibling
+   * Tests loading from actual filesystem path WITH fetchRemoteResources enabled
+   */
+  @Test
+  void testFileSiblingRef() throws Exception {
+    URL resourceUrl = getClass()
+      .getClassLoader()
+      .getResource("json_schemas/custom-parent-schema.json");
+    assertNotNull(resourceUrl, "Resource should exist");
+
+    Path schemaPath = Path.of(resourceUrl.toURI());
+
+    // MUST enable fetchRemoteResources for file:// $ref resolution
+    SchemaRegistry schemaRegistry = SchemaRegistry.withDialect(
+      Dialects.getDraft201909(),
+      builder -> builder.schemaLoader(loader -> loader.fetchRemoteResources())
+    );
+
+    Schema schema = schemaRegistry.getSchema(
+      SchemaLocation.of(schemaPath.toUri().toString())
+    );
+
+    List<Error> errors = schema.validate(
+      "{\"person\": {\"name\": \"John\"}}",
+      InputFormat.JSON
+    );
+    assertTrue(
+      errors.isEmpty(),
+      "Should validate with valid data. Errors: " + errors
+    );
+  }
+
+  /**
+   * Test 3: Pre-registering schemas in SchemaRegistry for $ref resolution
+   * Using absolute URIs as schema IDs so $ref can resolve them
+   */
+  @Test
+  void testPreRegisteredSchemasWithAbsoluteIds() throws Exception {
+    // Load both parent and child schemas
+    URL parentUrl = getClass()
+      .getClassLoader()
+      .getResource("json_schemas/custom-parent-schema.json");
+    URL childUrl = getClass()
+      .getClassLoader()
+      .getResource("json_schemas/custom-child-schema.json");
+
+    String parentContent = Files.readString(Path.of(parentUrl.toURI()));
+    String childContent = Files.readString(Path.of(childUrl.toURI()));
+
+    // Register schemas with absolute URIs as IDs (matching what $ref would resolve to)
+    String baseUri = parentUrl
+      .toString()
+      .substring(0, parentUrl.toString().lastIndexOf('/') + 1);
+    Map<String, String> schemas = Map.of(
+      baseUri + "custom-parent-schema.json",
+      parentContent,
+      baseUri + "custom-child-schema.json",
+      childContent
+    );
+
+    SchemaRegistry schemaRegistry = SchemaRegistry.withDialect(
+      Dialects.getDraft201909(),
+      builder -> builder.schemas(schemas)
+    );
+
+    // Load using the absolute URI
+    Schema schema = schemaRegistry.getSchema(
+      SchemaLocation.of(baseUri + "custom-parent-schema.json")
+    );
+
+    List<Error> errors = schema.validate(
+      "{\"person\": {\"name\": \"John\"}}",
+      InputFormat.JSON
+    );
+    assertTrue(
+      errors.isEmpty(),
+      "Should validate with valid data. Errors: " + errors
+    );
+
+    List<Error> invalidErrors = schema.validate(
+      "{\"person\": {}}",
+      InputFormat.JSON
+    );
+    assertFalse(
+      invalidErrors.isEmpty(),
+      "Should fail validation without required name"
+    );
+  }
+
+  /**
+   * Test 4: Using schemaIdResolvers to map IDs to classpath locations
+   */
+  @Test
+  void testSchemaIdResolverMapping() throws Exception {
+    SchemaRegistry schemaRegistry = SchemaRegistry.withDialect(
+      Dialects.getDraft201909(),
+      builder ->
+        builder.schemaIdResolvers(resolvers ->
+          resolvers.mapPrefix("my-schema:", "classpath:json_schemas/")
+        )
+    );
+
+    // This would work if our schema had "$id": "my-schema:custom-parent-schema.json"
+    // For now, just verify the resolver is configured
+    assertDoesNotThrow(() -> {
+      Schema schema = schemaRegistry.getSchema(
+        SchemaLocation.of("classpath:json_schemas/custom-parent-schema.json")
+      );
+      List<Error> errors = schema.validate(
+        "{\"person\": {\"name\": \"John\"}}",
+        InputFormat.JSON
+      );
+      assertTrue(errors.isEmpty());
+    });
+  }
+
+  /**
+   * Test 5: Nested directory structure with $ref
+   * Creates a temporary directory structure to test non-sibling refs
+   */
+  @Test
+  void testNestedDirectoryRef() throws Exception {
+    // Create temp directory structure
+    Path tempDir = Files.createTempDirectory("schema-test");
+    try {
+      Path schemasDir = Files.createDirectories(tempDir.resolve("schemas"));
+      Path definitionsDir = Files.createDirectories(
+        schemasDir.resolve("definitions")
+      );
+
+      // Create child schema in nested directory
+      String childSchema = """
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "value": {"type": "string"}
+          },
+          "required": ["value"]
+        }
+        """;
+      Files.writeString(definitionsDir.resolve("types.json"), childSchema);
+
+      // Create parent schema that refs nested child
+      String parentSchema = """
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "item": {"$ref": "definitions/types.json"}
+          },
+          "required": ["item"]
+        }
+        """;
+      Files.writeString(schemasDir.resolve("parent.json"), parentSchema);
+
+      // Test loading parent schema - MUST enable fetchRemoteResources for file:// $ref
+      SchemaRegistry schemaRegistry = SchemaRegistry.withDialect(
+        Dialects.getDraft201909(),
+        builder -> builder.schemaLoader(loader -> loader.fetchRemoteResources())
+      );
+
+      Schema schema = schemaRegistry.getSchema(
+        SchemaLocation.of(schemasDir.resolve("parent.json").toUri().toString())
+      );
+
+      List<Error> errors = schema.validate(
+        "{\"item\": {\"value\": \"test\"}}",
+        InputFormat.JSON
+      );
+      assertTrue(
+        errors.isEmpty(),
+        "Should validate nested ref. Errors: " + errors
+      );
+    } finally {
+      // Cleanup
+      deleteRecursively(tempDir);
+    }
+  }
+
+  /**
+   * Test 6: KEY TEST - Does fetchRemoteResources() fix file:// $ref resolution?
+   */
+  @Test
+  void testRemoteFetchingFixesFileRef() throws Exception {
+    URL resourceUrl = getClass()
+      .getClassLoader()
+      .getResource("json_schemas/custom-parent-schema.json");
+    assertNotNull(resourceUrl, "Resource should exist");
+
+    Path schemaPath = Path.of(resourceUrl.toURI());
+
+    // Create registry WITH remote fetching enabled
+    SchemaRegistry schemaRegistryWithRemote = SchemaRegistry.withDialect(
+      Dialects.getDraft201909(),
+      builder -> builder.schemaLoader(loader -> loader.fetchRemoteResources())
+    );
+
+    // Try loading with file:// URI and remote fetching enabled
+    assertDoesNotThrow(() -> {
+      Schema schema = schemaRegistryWithRemote.getSchema(
+        SchemaLocation.of(schemaPath.toUri().toString())
+      );
+
+      List<Error> errors = schema.validate(
+        "{\"person\": {\"name\": \"John\"}}",
+        InputFormat.JSON
+      );
+      assertTrue(
+        errors.isEmpty(),
+        "Should validate with valid data. Errors: " + errors
+      );
+    }, "file:// $ref SHOULD work with fetchRemoteResources() enabled");
+  }
+
+  /**
+   * Test 6b: Control test - Verify file:// still fails WITHOUT remote fetching
+   */
+  @Test
+  void testFileRefFailsWithoutRemoteFetching() throws Exception {
+    URL resourceUrl = getClass()
+      .getClassLoader()
+      .getResource("json_schemas/custom-parent-schema.json");
+    assertNotNull(resourceUrl, "Resource should exist");
+
+    Path schemaPath = Path.of(resourceUrl.toURI());
+
+    // Create registry WITHOUT remote fetching (default)
+    SchemaRegistry schemaRegistry = SchemaRegistry.withDialect(
+      Dialects.getDraft201909()
+    );
+
+    // This should fail because $ref can't be resolved
+    assertThrows(
+      Exception.class,
+      () -> {
+        Schema schema = schemaRegistry.getSchema(
+          SchemaLocation.of(schemaPath.toUri().toString())
+        );
+        schema.validate("{\"person\": {\"name\": \"John\"}}", InputFormat.JSON);
+      },
+      "file:// $ref should fail without fetchRemoteResources()"
+    );
+  }
+
+  /**
+   * Test 7: Loading schema without $id (uses retrieval IRI as schema ID)
+   */
+  @Test
+  void testSchemaWithoutId() throws Exception {
+    // Our test schemas don't have $id, so they should use the retrieval IRI as their ID
+    SchemaRegistry schemaRegistry = SchemaRegistry.withDialect(
+      Dialects.getDraft201909()
+    );
+
+    assertDoesNotThrow(() -> {
+      Schema schema = schemaRegistry.getSchema(
+        SchemaLocation.of("classpath:json_schemas/custom-child-schema.json")
+      );
+
+      // Validate directly
+      List<Error> errors = schema.validate(
+        "{\"name\": \"test\"}",
+        InputFormat.JSON
+      );
+      assertTrue(
+        errors.isEmpty(),
+        "Schema without $id should work. Errors: " + errors
+      );
+    });
+  }
+
+  private void deleteRecursively(Path path) throws IOException {
+    if (Files.isDirectory(path)) {
+      try (var stream = Files.list(path)) {
+        stream.forEach(p -> {
+          try {
+            deleteRecursively(p);
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        });
+      }
+    }
+    Files.deleteIfExists(path);
+  }
+}

--- a/src/test/resources/json_schemas/classpath-ref-test-parent.json
+++ b/src/test/resources/json_schemas/classpath-ref-test-parent.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "Classpath Ref Test Parent",
+  "type": "object",
+  "properties": {
+    "person": {
+      "$ref": "custom-child-schema.json"
+    }
+  },
+  "required": ["person"]
+}

--- a/src/test/resources/json_schemas/custom-child-schema.json
+++ b/src/test/resources/json_schemas/custom-child-schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "Custom Child Schema",
+  "description": "A simple schema that validates a name property",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "required": ["name"]
+}

--- a/src/test/resources/json_schemas/custom-parent-schema.json
+++ b/src/test/resources/json_schemas/custom-parent-schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "Custom Parent Schema",
+  "description": "A parent schema that references a child schema via $ref",
+  "type": "object",
+  "properties": {
+    "person": {
+      "$ref": "custom-child-schema.json"
+    }
+  },
+  "required": ["person"]
+}


### PR DESCRIPTION
The validator had two major releases in the last months, and not only are there breaking changes (e.g. I needed to change $refs to $dynamicRefs at some point), but also the overall API changed. I plan to first migrate to 2.x before then doing the (apparently small) step to 3.x.

While tests do run now, I need to review the code, the tests, clan up, and see if it really makes sense (maybe add some more tests).